### PR TITLE
Fix for Memory Leak in cdist and Metric-Like Functions

### DIFF
--- a/python/lib.c
+++ b/python/lib.c
@@ -319,6 +319,19 @@ static PyObject* impl_cdist(                            //
             goto cleanup;
         }
 
+        PyObject *wrapper = PyCapsule_New(distances, "wrapper", NULL);
+        if (!wrapper) {
+            free(distances);
+            Py_DECREF(output_array);
+            goto cleanup;
+        }
+
+        if (PyArray_SetBaseObject((PyArrayObject *)output_array, wrapper) < 0) {
+            Py_DECREF(output_array);
+            Py_DECREF(wrapper);
+            goto cleanup;
+        }
+
         output = output_array;
     }
 


### PR DESCRIPTION
# Fix for Memory Leak in cdist and Metric-Like Functions
alert(gpt)

## Problem Description
I identified a memory leak issue in the `cdist` function, as well as other metric-like functions, within our codebase. This leak becomes evident in scenarios where these functions are called repeatedly, such as within a `while True` loop. An example to demonstrate the issue is as follows:

```python
while True:
    simsimd.cdist(embeddings, query)
```

This code snippet leads to a gradual increase in memory usage over time, indicating a memory leak.

## Root Cause
The memory leak stems from the improper handling of numpy arrays, particularly in the context of garbage collection (GC). The issue arises when PyArray_NewFromDescr is used with non-null data. In such cases, the data must remain alive for the entire lifetime of the array. However, it is crucial to allow both numpy and Python's garbage collector to deallocate the array when it is no longer in use.

## Solution
According to the numpy C-API documentation ([Numpy C-API Array From Scratch](https://numpy.org/devdocs/reference/c-api/array.html#from-scratch)), the constant NPY_ARRAY_OWNDATA should not be used manually. The documentation states:

"The data area is owned by this array. Should never be set manually, instead create a PyObject wrapping the data and set the array’s base to that object. For an example, see the test in test_mem_policy."

Following the guidelines from the numpy documentation, I referred to a specific implementation in the numpy repository for guidance. The reference code can be found here: [Numpy Test Memory Policy](https://github.com/numpy/numpy/blob/main/numpy/_core/tests/test_mem_policy.py#L84C22-L84C22). By aligning our implementation with the approach demonstrated in this example, I was able to resolve the memory leak issue.