### PR TITLE
golang: fix some issues in golang bindings

### DIFF
--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -3,7 +3,7 @@ package simsimd
 /*
 #cgo CFLAGS: -O3
 #cgo LDFLAGS: -O3 -L.
-#include "../simsimd/simsimd.h"
+#include "../include/simsimd/simsimd.h"
 #include <stdlib.h>
 
 inline static simsimd_f32_t cosine_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }

--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -7,7 +7,7 @@ package simsimd
 #include <stdlib.h>
 
 inline static simsimd_f32_t cosine_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t cosine_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_neon_f32_cos(a, b, d); }
+inline static simsimd_f32_t cosine_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_f32_k, simsimd_cap_any_k)(a, b, d, d); }
 inline static simsimd_f32_t inner_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }
 inline static simsimd_f32_t inner_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_f32_k, simsimd_cap_any_k)(a, b, d, d); }
 inline static simsimd_f32_t sqeuclidean_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_sqeuclidean_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }

--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -2,7 +2,7 @@ package simsimd
 
 /*
 #cgo CFLAGS: -O3
-#cgo LDFLAGS: -O3 -L.
+#cgo LDFLAGS: -O3 -L. -lm
 #include "../include/simsimd/simsimd.h"
 #include <stdlib.h>
 

--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -15,13 +15,12 @@ inline static simsimd_f32_t sqeuclidean_f32(simsimd_f32_t const* a, simsimd_f32_
 */
 import "C"
 
-
 // CosineI8 computes the cosine distance between two i8 vectors using the most suitable SIMD instruction set available.
 func CosineI8(a, b []int8) float32 {
 	return float32(C.cosine_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
-// CosineF32 computes the cosine distance between two i8 vectors using the most suitable SIMD instruction set available.
+// CosineF32 computes the cosine distance between two f32 vectors using the most suitable SIMD instruction set available.
 func CosineF32(a, b []float32) float32 {
 	return float32(C.cosine_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
@@ -31,7 +30,7 @@ func InnerI8(a, b []int8) float32 {
 	return float32(C.inner_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
-// InnerF32 computes the inner-product similarity between two i8 vectors using the most suitable SIMD instruction set available.
+// InnerF32 computes the inner-product similarity between two f32 vectors using the most suitable SIMD instruction set available.
 func InnerF32(a, b []float32) float32 {
 	return float32(C.inner_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
@@ -41,7 +40,7 @@ func SqEuclideanI8(a, b []int8) float32 {
 	return float32(C.sqeuclidean_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
-// SqEuclideanF32 computes the squared euclidean similarity between two i8 vectors using the most suitable SIMD instruction set available.
+// SqEuclideanF32 computes the squared euclidean similarity between two f32 vectors using the most suitable SIMD instruction set available.
 func SqEuclideanF32(a, b []float32) float32 {
 	return float32(C.sqeuclidean_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }

--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -17,30 +17,54 @@ import "C"
 
 // CosineI8 computes the cosine distance between two i8 vectors using the most suitable SIMD instruction set available.
 func CosineI8(a, b []int8) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.cosine_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
 // CosineF32 computes the cosine distance between two f32 vectors using the most suitable SIMD instruction set available.
 func CosineF32(a, b []float32) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.cosine_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
 // InnerI8 computes the inner-product similarity between two i8 vectors using the most suitable SIMD instruction set available.
 func InnerI8(a, b []int8) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.inner_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
 // InnerF32 computes the inner-product similarity between two f32 vectors using the most suitable SIMD instruction set available.
 func InnerF32(a, b []float32) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.inner_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
 // SqEuclideanI8 computes the squared euclidean similarity between two i8 vectors using the most suitable SIMD instruction set available.
 func SqEuclideanI8(a, b []int8) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.sqeuclidean_i8((*C.simsimd_i8_t)(&a[0]), (*C.simsimd_i8_t)(&b[0]), C.simsimd_size_t(len(a))))
 }
 
 // SqEuclideanF32 computes the squared euclidean similarity between two f32 vectors using the most suitable SIMD instruction set available.
 func SqEuclideanF32(a, b []float32) float32 {
+	if len(a) != len(b) {
+		panic("both vectors must have the same length")
+	}
+
 	return float32(C.sqeuclidean_f32((*C.simsimd_f32_t)(&a[0]), (*C.simsimd_f32_t)(&b[0]), C.simsimd_size_t(len(a))))
 }


### PR DESCRIPTION
### golang: correct data type in function comments

Update the comments for CosineF32, InnerF32, and SqEuclideanF32
functions in the simsimd.go file. The comments incorrectly stated
that these functions compute the similarity between two i8 vectors.
They actually compute the similarity between two f32 vectors. This
change ensures that the comments accurately reflect the
functionality of the code.

### golang: change simsimd header file path

The path to the simsimd header file is updated. The header file is
in the 'include' directory.

### golang: link math library in golang simsimd

The math library is now linked in the golang simsimd file. The change was
necessary to resolve undefined references to `logf` and `sqrtf`.

### golang: update cosine_f32 function in simsimd.go

The cosine_f32 function in simsimd.go has been updated to use
simsimd_metric_punned instead of simsimd_neon_f32_cos. This change was
necessary to ensure compatibility across different SIMD architectures.
The previous implementation was specific to NEON, which could cause
issues on systems that do not support it.

This resolves the error:

```
./simsimd.go: In function 'cosine_f32':
./simsimd.go:10:115: warning: implicit declaration of function 'simsimd_neon_f32_cos'; did you mean 'simsimd_serial_f32_cos'?  [-Wimplicit-function-declaration]
```

### golang: add length check to vector operations in simsimd.go

Ensure that input vectors to the CosineI8, CosineF32, InnerI8, InnerF32,
SqEuclideanI8, and SqEuclideanF32 functions have the same length. This
prevents potential runtime errors when the functions are called with
vectors of different lengths. The functions now panic with a descriptive
message if the lengths do not match.