### PR TITLE
golang: separate c functions and cache simsimd_metric_punned

### DIFF
--- a/golang/simsimd.c
+++ b/golang/simsimd.c
@@ -1,0 +1,57 @@
+#include <stdlib.h>
+#define SIMSIMD_NATIVE_F16 (0)
+#include "../include/simsimd/simsimd.h"
+
+inline static simsimd_f32_t 
+cosine_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) {
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_i8_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}
+
+inline static simsimd_f32_t 
+cosine_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { 
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_f32_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}
+
+inline static simsimd_f32_t 
+inner_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { 
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_i8_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}
+
+inline static simsimd_f32_t 
+inner_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { 
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_f32_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}
+
+inline static simsimd_f32_t 
+sqeuclidean_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { 
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_sqeuclidean_k, simsimd_datatype_i8_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}
+
+inline static simsimd_f32_t 
+sqeuclidean_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { 
+    static simsimd_metric_punned_t fn;
+    if (!fn) {
+        fn = simsimd_metric_punned(simsimd_metric_sqeuclidean_k, simsimd_datatype_f32_k, simsimd_cap_any_k);
+    }
+    return fn(a, b, d, d); 
+}

--- a/golang/simsimd.go
+++ b/golang/simsimd.go
@@ -3,15 +3,8 @@ package simsimd
 /*
 #cgo CFLAGS: -O3
 #cgo LDFLAGS: -O3 -L. -lm
-#include "../include/simsimd/simsimd.h"
-#include <stdlib.h>
 
-inline static simsimd_f32_t cosine_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t cosine_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_cosine_k, simsimd_datatype_f32_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t inner_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t inner_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_inner_k, simsimd_datatype_f32_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t sqeuclidean_i8(simsimd_i8_t const* a, simsimd_i8_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_sqeuclidean_k, simsimd_datatype_i8_k, simsimd_cap_any_k)(a, b, d, d); }
-inline static simsimd_f32_t sqeuclidean_f32(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t d) { return simsimd_metric_punned(simsimd_metric_sqeuclidean_k, simsimd_datatype_f32_k, simsimd_cap_any_k)(a, b, d, d); }
+#include "simsimd.c"
 */
 import "C"
 


### PR DESCRIPTION
The changes move the inline C functions from simsimd.go to a new file, simsimd.c.
This separation enhances code organization and readability. It also allows for
better management of the C code, which can now be modified independently from
the Go code.

More importantly, we now cache the results from simsimd_metric_punned
instead of determining the capabilities for each call. This improves the
benchmark from 1940ns/op to 1320ns/op on my system.
