### PR TITLE
Fix: Forward SIMSIMD_NATIVE_F16 (#78)

### DIFF
--- a/include/simsimd/types.h
+++ b/include/simsimd/types.h
@@ -102,7 +102,7 @@ typedef signed char simsimd_i8_t;
 typedef unsigned char simsimd_b8_t;
 typedef unsigned long long simsimd_size_t;
 
-#if !defined(SIMSIMD_NATIVE_F16)
+#if !defined(SIMSIMD_NATIVE_F16) || SIMSIMD_NATIVE_F16
 /**
  *  @brief  Half-precision floating-point type.
  *
@@ -112,12 +112,16 @@ typedef unsigned long long simsimd_size_t;
  */
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__ARM_ARCH) || defined(__aarch64__)) &&                      \
     (defined(__ARM_FP16_FORMAT_IEEE))
+#if !defined(SIMSIMD_NATIVE_F16)
 #define SIMSIMD_NATIVE_F16 1
+#endif
 typedef __fp16 simsimd_f16_t;
 #elif ((defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(__i386__)) &&                      \
        (defined(__SSE2__) || defined(__AVX512F__)))
 typedef _Float16 simsimd_f16_t;
+#if !defined(SIMSIMD_NATIVE_F16)
 #define SIMSIMD_NATIVE_F16 1
+#endif
 #else // Unknown compiler or architecture
 #define SIMSIMD_NATIVE_F16 0
 #endif // Unknown compiler or architecture


### PR DESCRIPTION
USearch depends on this behavior and expects SimSIMD to define `simsimd_f16_t` when passing in SIMSIMD_NATIVE_F16=1 [1].

[1]:
https://github.com/unum-cloud/usearch/blob/ce54b814a8a10f4c0c32fee7aad9451231b63f75/include/usearch/index_plugins.hpp#L50