### PR TITLE
Improve Rust bench performance and style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "simsimd"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "cc",
  "criterion",

--- a/rust/benches/native.rs
+++ b/rust/benches/native.rs
@@ -10,18 +10,21 @@ pub(crate) fn cosine_similarity_cpu(a: &[f32], b: &[f32]) -> Option<f32> {
         return None;
     }
 
-    let dot_product: f32 = a.iter().zip(b.iter()).map(|(a, b)| a * b).sum();
-    let norm_a: f32 = a.iter().map(|a| a.powf(2.0)).sum();
-    let norm_b: f32 = b.iter().map(|b| b.powf(2.0)).sum();
+    let (dot_product, norm_a, norm_b) = a
+        .iter()
+        .zip(b)
+        .map(|(a, b)| (a * b, a * a, b * b))
+        .fold((0.0, 0.0, 0.0), |acc, x| {
+            (acc.0 + x.0, acc.1 + x.1, acc.2 + x.2)
+        });
 
     Some(1.0 - (dot_product / (norm_a.sqrt() * norm_b.sqrt())))
 }
 
-pub(crate) fn squared_euclidean_cpu(a: &[f32], b: &[f32]) -> f32 {
-    assert_eq!(a.len(), b.len());
+pub(crate) fn squared_euclidean_cpu(a: &[f32], b: &[f32]) -> Option<f32> {
+    if a.len() != b.len() {
+        return None;
+    }
 
-    a.iter()
-        .zip(b.iter())
-        .map(|(x, y)| ((*x) - (*y)) * ((*x) - (*y)))
-        .fold(0.0, ::std::ops::Add::add)
+    Some(a.iter().zip(b).map(|(x, y)| (x - y).powi(2)).sum())
 }


### PR DESCRIPTION
The rust version of cosine_similiraty, which SimSIMD is compared against, was using three separate iterators to calculate intermediate values. 
Combining the iterators into one made the reference speedup by ~200%.

I also went ahead and cleaned up the reference squared_euclidean implementation to follow the same structure (Option instead of assert) and made the iterator more succinct.