### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 #   * running thousands of fuzzy tests on each wheel.
 #   = meaning 16 platforms * 7 Python versions = 112 builds.
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a