### PR TITLE
Fix linking to the correct OpenMP library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if sys.platform == "linux":
 
     # Enable OpenMP for Linux
     compile_args.append("-fopenmp")
-    link_args.append("-lgomp")
+    link_args.append("-fopenmp")
 
     # Add vectorized `logf` implementation from the `glibc`
     link_args.append("-lm")


### PR DESCRIPTION
Replace the hardcoded `-lomp` with `-fopenmp` to ensure that the compiler uses the correct OpenMP library.  This is necessary for Clang to correctly link against its own OpenMP implementation, rather than compiling against LLVM OpenMP, then trying to link against libgomp.