### PR TITLE
Fix: ***WARNING*** Library was built as DEBUG. Timings may be affected.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,11 @@ if(SIMSIMD_BUILD_BENCHMARKS)
     GIT_TAG v1.7.0)
   FetchContent_MakeAvailable(benchmark)
 
+  # Remove the google benchmark built in debug warning
+  if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions( benchmark PRIVATE NDEBUG ) 
+  endif()
+
   find_package(Threads REQUIRED)
   add_executable(simsimd_bench cpp/bench.cxx)
   target_link_libraries(simsimd_bench simsimd Threads::Threads benchmark)


### PR DESCRIPTION
When google benchmark is built with cmake you must define `NDEBUG` when doing a release build or it will build in asserts and complain with

```***WARNING*** Library was built as DEBUG. Timings may be affected.```


