### PR TITLE
Dev/eknag/bf16 cossim matmul

### DIFF
--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -300,13 +300,39 @@ SIMSIMD_PUBLIC void simsimd_cos_f16_neon(simsimd_f16_t const* a, simsimd_f16_t c
 
 SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_t const* b, simsimd_size_t n,
                                           simsimd_distance_t* result) {
-    float32x4_t products_low_vec = vdupq_n_f32(0.0f);
-    float32x4_t products_high_vec = vdupq_n_f32(0.0f);
-    //float32x4_t ab_high_vec = vdupq_n_f32(0), ab_low_vec = vdupq_n_f32(0);
-    //float32x4_t a2_high_vec = vdupq_n_f32(0), a2_low_vec = vdupq_n_f32(0);
-    //float32x4_t b2_high_vec = vdupq_n_f32(0), b2_low_vec = vdupq_n_f32(0);
+
+    // Similar to `simsimd_cos_i8_neon`, we can use the `BFMMLA` instruction through
+    // the `vbfmmlaq_f32` intrinsic to compute matrix products and later drop 1/4 of values.
+    // The only difference is that `zip` isn't provided for `bf16` and we need to reinterpret back
+    // and forth before zipping. Same as with integers, on modern Arm CPUs, this "smart"
+    // approach is actually slower by around 25%.
+    //
+    //   float32x4_t products_low_vec = vdupq_n_f32(0.0f);
+    //   float32x4_t products_high_vec = vdupq_n_f32(0.0f);
+    //   for (; i + 8 <= n; i += 8) {
+    //       bfloat16x8_t a_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)a + i);
+    //       bfloat16x8_t b_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)b + i);
+    //       int16x8_t a_vec_s16 = vreinterpretq_s16_bf16(a_vec);
+    //       int16x8_t b_vec_s16 = vreinterpretq_s16_bf16(b_vec);
+    //       int16x8x2_t y_w_vecs_s16 = vzipq_s16(a_vec_s16, b_vec_s16);
+    //       bfloat16x8_t y_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[0]);
+    //       bfloat16x8_t w_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[1]);
+    //       bfloat16x4_t a_low = vget_low_bf16(a_vec);
+    //       bfloat16x4_t b_low = vget_low_bf16(b_vec);
+    //       bfloat16x4_t a_high = vget_high_bf16(a_vec);
+    //       bfloat16x4_t b_high = vget_high_bf16(b_vec);
+    //       bfloat16x8_t x_vec = vcombine_bf16(a_low, b_low);
+    //       bfloat16x8_t v_vec = vcombine_bf16(a_high, b_high);
+    //       products_low_vec = vbfmmlaq_f32(products_low_vec, x_vec, y_vec);
+    //       products_high_vec = vbfmmlaq_f32(products_high_vec, v_vec, w_vec);
+    //   }
+    //   float32x4_t products_vec = vaddq_f32(products_high_vec, products_low_vec);
+    //   simsimd_f32_t a2 = products_vec[0], ab = products_vec[1], b2 = products_vec[3];
+
+    float32x4_t ab_high_vec = vdupq_n_f32(0), ab_low_vec = vdupq_n_f32(0);
+    float32x4_t a2_high_vec = vdupq_n_f32(0), a2_low_vec = vdupq_n_f32(0);
+    float32x4_t b2_high_vec = vdupq_n_f32(0), b2_low_vec = vdupq_n_f32(0);
     simsimd_size_t i = 0;
-    /*
     for (; i + 8 <= n; i += 8) {
         bfloat16x8_t a_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)a + i);
         bfloat16x8_t b_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)b + i);
@@ -317,11 +343,11 @@ SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_
         b2_high_vec = vbfmlaltq_f32(b2_high_vec, b_vec, b_vec);
         b2_low_vec = vbfmlalbq_f32(b2_low_vec, b_vec, b_vec);
     }
-    */
+
     // In case the software emulation for `bf16` scalars is enabled, the `simsimd_uncompress_bf16`
     // function will run. It is extremely slow, so even for the tail, let's combine serial
     // loads and stores with vectorized math.
-    /*if (i < n) {
+    if (i < n) {
         union {
             bfloat16x8_t bf16_vec;
             simsimd_bf16_t bf16[8];
@@ -340,43 +366,9 @@ SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_
     }
 
     // Avoid `simsimd_approximate_inverse_square_root` on Arm NEON
-    
     simsimd_f32_t ab = vaddvq_f32(vaddq_f32(ab_high_vec, ab_low_vec)),
                   a2 = vaddvq_f32(vaddq_f32(a2_high_vec, a2_low_vec)),
                   b2 = vaddvq_f32(vaddq_f32(b2_high_vec, b2_low_vec));
-    */
-
-    for (; i + 8 <= n; i += 8) {
-        bfloat16x8_t a_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)a + i);
-        bfloat16x8_t b_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)b + i);
-                // Reinterpret bf16 vectors as s16 vectors
-        int16x8_t a_vec_s16 = vreinterpretq_s16_bf16(a_vec);
-        int16x8_t b_vec_s16 = vreinterpretq_s16_bf16(b_vec);
-
-        // Interleave elements using vzipq_s16
-        int16x8x2_t y_w_vecs_s16 = vzipq_s16(a_vec_s16, b_vec_s16);
-
-        // Reinterpret back to bf16 vectors
-        bfloat16x8_t y_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[0]);
-        bfloat16x8_t w_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[1]);
-
-        bfloat16x4_t a_low = vget_low_bf16(a_vec);
-        bfloat16x4_t b_low = vget_low_bf16(b_vec);
-
-        bfloat16x4_t a_high = vget_high_bf16(a_vec);
-        bfloat16x4_t b_high = vget_high_bf16(b_vec);
-
-        bfloat16x8_t x_vec = vcombine_bf16(a_low, b_low);
-        bfloat16x8_t v_vec = vcombine_bf16(a_high, b_high);
-
-        products_low_vec = vbfmmlaq_f32(products_low_vec, x_vec, y_vec);
-        products_high_vec = vbfmmlaq_f32(products_high_vec, v_vec, w_vec);
-    }
-    float32x4_t products_vec = vaddq_f32(products_high_vec, products_low_vec);
-    simsimd_f32_t a2 = products_vec[0],
-                  ab = products_vec[1],
-                  b2 = products_vec[3];
- 
     simsimd_f32_t a2_b2_arr[2] = {a2, b2};
     float32x2_t a2_b2 = vld1_f32(a2_b2_arr);
     a2_b2 = vrsqrte_f32(a2_b2);

--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -300,11 +300,13 @@ SIMSIMD_PUBLIC void simsimd_cos_f16_neon(simsimd_f16_t const* a, simsimd_f16_t c
 
 SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_t const* b, simsimd_size_t n,
                                           simsimd_distance_t* result) {
-    // TODO: Redo with BFMMLA - vbfmmlaq_f32
-    float32x4_t ab_high_vec = vdupq_n_f32(0), ab_low_vec = vdupq_n_f32(0);
-    float32x4_t a2_high_vec = vdupq_n_f32(0), a2_low_vec = vdupq_n_f32(0);
-    float32x4_t b2_high_vec = vdupq_n_f32(0), b2_low_vec = vdupq_n_f32(0);
+    float32x4_t products_low_vec = vdupq_n_f32(0.0f);
+    float32x4_t products_high_vec = vdupq_n_f32(0.0f);
+    //float32x4_t ab_high_vec = vdupq_n_f32(0), ab_low_vec = vdupq_n_f32(0);
+    //float32x4_t a2_high_vec = vdupq_n_f32(0), a2_low_vec = vdupq_n_f32(0);
+    //float32x4_t b2_high_vec = vdupq_n_f32(0), b2_low_vec = vdupq_n_f32(0);
     simsimd_size_t i = 0;
+    /*
     for (; i + 8 <= n; i += 8) {
         bfloat16x8_t a_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)a + i);
         bfloat16x8_t b_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)b + i);
@@ -315,11 +317,11 @@ SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_
         b2_high_vec = vbfmlaltq_f32(b2_high_vec, b_vec, b_vec);
         b2_low_vec = vbfmlalbq_f32(b2_low_vec, b_vec, b_vec);
     }
-
+    */
     // In case the software emulation for `bf16` scalars is enabled, the `simsimd_uncompress_bf16`
     // function will run. It is extremely slow, so even for the tail, let's combine serial
     // loads and stores with vectorized math.
-    if (i < n) {
+    /*if (i < n) {
         union {
             bfloat16x8_t bf16_vec;
             simsimd_bf16_t bf16[8];
@@ -338,9 +340,43 @@ SIMSIMD_PUBLIC void simsimd_cos_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_
     }
 
     // Avoid `simsimd_approximate_inverse_square_root` on Arm NEON
+    
     simsimd_f32_t ab = vaddvq_f32(vaddq_f32(ab_high_vec, ab_low_vec)),
                   a2 = vaddvq_f32(vaddq_f32(a2_high_vec, a2_low_vec)),
                   b2 = vaddvq_f32(vaddq_f32(b2_high_vec, b2_low_vec));
+    */
+
+    for (; i + 8 <= n; i += 8) {
+        bfloat16x8_t a_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)a + i);
+        bfloat16x8_t b_vec = vld1q_bf16((simsimd_bf16_for_arm_simd_t const*)b + i);
+                // Reinterpret bf16 vectors as s16 vectors
+        int16x8_t a_vec_s16 = vreinterpretq_s16_bf16(a_vec);
+        int16x8_t b_vec_s16 = vreinterpretq_s16_bf16(b_vec);
+
+        // Interleave elements using vzipq_s16
+        int16x8x2_t y_w_vecs_s16 = vzipq_s16(a_vec_s16, b_vec_s16);
+
+        // Reinterpret back to bf16 vectors
+        bfloat16x8_t y_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[0]);
+        bfloat16x8_t w_vec = vreinterpretq_bf16_s16(y_w_vecs_s16.val[1]);
+
+        bfloat16x4_t a_low = vget_low_bf16(a_vec);
+        bfloat16x4_t b_low = vget_low_bf16(b_vec);
+
+        bfloat16x4_t a_high = vget_high_bf16(a_vec);
+        bfloat16x4_t b_high = vget_high_bf16(b_vec);
+
+        bfloat16x8_t x_vec = vcombine_bf16(a_low, b_low);
+        bfloat16x8_t v_vec = vcombine_bf16(a_high, b_high);
+
+        products_low_vec = vbfmmlaq_f32(products_low_vec, x_vec, y_vec);
+        products_high_vec = vbfmmlaq_f32(products_high_vec, v_vec, w_vec);
+    }
+    float32x4_t products_vec = vaddq_f32(products_high_vec, products_low_vec);
+    simsimd_f32_t a2 = products_vec[0],
+                  ab = products_vec[1],
+                  b2 = products_vec[3];
+ 
     simsimd_f32_t a2_b2_arr[2] = {a2, b2};
     float32x2_t a2_b2 = vld1_f32(a2_b2_arr);
     a2_b2 = vrsqrte_f32(a2_b2);


### PR DESCRIPTION
Add benchmark - only bf16 cos implementations that leverages vbfmmlaq_f32 instead of 3 seperate dot products.