### PR TITLE
Expose bf16 to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "simsimd"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "cc",
  "criterion",


### PR DESCRIPTION
As we discussed in #124, the new `bf16` type and related functions were forgotten to be exposed on the Rust side, so I just quickly added these! 

I just took a quick look and seems like there are unexposed types and methods in other languages as well:
- JS: `f16`, `bf16`
- Swift: `bf16`
- Go: `f16`, `bf16`

Could you please confirm? If so, would you like to add the missing bindings for these as well? 