### PR TITLE
Improve: Use the neon dot product intrinsic for `dot_bf16_neon`

### DIFF
--- a/include/simsimd/dot.h
+++ b/include/simsimd/dot.h
@@ -506,6 +506,7 @@ SIMSIMD_INTERNAL bfloat16x8_t simsimd_partial_load_bf16x8_neon(simsimd_bf16_t co
 SIMSIMD_PUBLIC void simsimd_dot_bf16_neon(simsimd_bf16_t const* a, simsimd_bf16_t const* b, simsimd_size_t n,
                                           simsimd_distance_t* result) {
     float32x4_t ab_vec = vdupq_n_f32(0);
+    bfloat16x8_t a_vec, b_vec;
     
 simsimd_dot_bf16_neon_cycle:
     if (n < 8) {


### PR DESCRIPTION
PR for https://github.com/ashvardanian/SimSIMD/issues/167

`simsimd_dot_bf16_neon` has been updated to use the neon dot product intrinsic `vbfdotq_f32` for a 25% speedup.   I have only tested this on AWS t4g and c7g instances.  

Also fixed a couple typos.  simsimd_dot_i8_serial was used instead of _neon, the bf16_neon declarations were missing, and a trailing // was seen on line 526. 