### PR TITLE
Double-precision improvements on Arm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -151,6 +151,7 @@
         "tanimoto",
         "tparam",
         "typedarray",
+        "unclipped",
         "unnormalized",
         "unsw",
         "Vardanian",

--- a/cpp/bench.cxx
+++ b/cpp/bench.cxx
@@ -648,6 +648,9 @@ int main(int argc, char** argv) {
     dense_<f32_k>("kl_f32_neon", simsimd_kl_f32_neon, simsimd_kl_f32_accurate);
     dense_<f32_k>("js_f32_neon", simsimd_js_f32_neon, simsimd_js_f32_accurate);
 
+    dense_<f64_k>("cos_f64_neon", simsimd_cos_f64_neon, simsimd_cos_f64_serial);
+    dense_<f64_k>("l2sq_f64_neon", simsimd_l2sq_f64_neon, simsimd_l2sq_f64_serial);
+
     dense_<i8_k>("cos_i8_neon", simsimd_cos_i8_neon, simsimd_cos_i8_accurate);
     dense_<i8_k>("dot_i8_neon", simsimd_dot_i8_neon, simsimd_dot_i8_serial);
     dense_<i8_k>("l2sq_i8_neon", simsimd_l2sq_i8_neon, simsimd_l2sq_i8_accurate);

--- a/include/simsimd/simsimd.h
+++ b/include/simsimd/simsimd.h
@@ -541,6 +541,14 @@ SIMSIMD_PUBLIC void simsimd_find_metric_punned( //
             default: break;
             }
 #endif
+#if SIMSIMD_TARGET_NEON
+        if (viable & simsimd_cap_neon_k)
+            switch (kind) {
+            case simsimd_metric_cos_k: *m = (m_t)&simsimd_cos_f64_neon, *c = simsimd_cap_neon_k; return;
+            case simsimd_metric_l2sq_k: *m = (m_t)&simsimd_l2sq_f64_neon, *c = simsimd_cap_neon_k; return;
+            default: break;
+            }
+#endif
 #if SIMSIMD_TARGET_SKYLAKE
         if (viable & simsimd_cap_skylake_k)
             switch (kind) {
@@ -1535,6 +1543,8 @@ SIMSIMD_PUBLIC void simsimd_cos_f64(simsimd_f64_t const* a, simsimd_f64_t const*
                                     simsimd_distance_t* d) {
 #if SIMSIMD_TARGET_SVE
     simsimd_cos_f64_sve(a, b, n, d);
+#elif SIMSIMD_TARGET_NEON
+    simsimd_cos_f64_neon(a, b, n, d);
 #elif SIMSIMD_TARGET_SKYLAKE
     simsimd_cos_f64_skylake(a, b, n, d);
 #else
@@ -1587,6 +1597,8 @@ SIMSIMD_PUBLIC void simsimd_l2sq_f64(simsimd_f64_t const* a, simsimd_f64_t const
                                      simsimd_distance_t* d) {
 #if SIMSIMD_TARGET_SVE
     simsimd_l2sq_f64_sve(a, b, n, d);
+#elif SIMSIMD_TARGET_NEON
+    simsimd_l2sq_f64_neon(a, b, n, d);
 #elif SIMSIMD_TARGET_SKYLAKE
     simsimd_l2sq_f64_skylake(a, b, n, d);
 #else

--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -210,7 +210,8 @@ SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f32_neon(simsimd_f32_
     rsqrts = vmul_f32(rsqrts, vrsqrts_f32(vmul_f32(squares, rsqrts), rsqrts));
     rsqrts = vmul_f32(rsqrts, vrsqrts_f32(vmul_f32(squares, rsqrts), rsqrts));
     vst1_f32(squares_arr, rsqrts);
-    return 1 - ab * squares_arr[0] * squares_arr[1];
+    simsimd_distance_t result = 1 - ab * squares_arr[0] * squares_arr[1];
+    return result > 0 ? result : 0;
 }
 
 SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f64_neon(simsimd_f64_t ab, simsimd_f64_t a2,
@@ -233,7 +234,8 @@ SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f64_neon(simsimd_f64_
     rsqrts = vmulq_f64(rsqrts, vrsqrtsq_f64(vmulq_f64(squares, rsqrts), rsqrts));
     rsqrts = vmulq_f64(rsqrts, vrsqrtsq_f64(vmulq_f64(squares, rsqrts), rsqrts));
     vst1q_f64(squares_arr, rsqrts);
-    return 1 - ab * squares_arr[0] * squares_arr[1];
+    simsimd_distance_t result = 1 - ab * squares_arr[0] * squares_arr[1];
+    return result > 0 ? result : 0;
 }
 
 SIMSIMD_PUBLIC void simsimd_l2sq_f32_neon(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t n,
@@ -820,7 +822,8 @@ SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f64_haswell(simsimd_f
 
     simsimd_f64_t a2_reciprocal = _mm_cvtsd_f64(_mm_unpackhi_pd(rsqrts, rsqrts));
     simsimd_f64_t b2_reciprocal = _mm_cvtsd_f64(rsqrts);
-    return 1 - ab * a2_reciprocal * b2_reciprocal;
+    simsimd_distance_t result = 1 - ab * a2_reciprocal * b2_reciprocal;
+    return result > 0 ? result : 0;
 }
 
 SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f32_haswell(simsimd_f32_t ab, simsimd_f32_t a2,
@@ -852,7 +855,8 @@ SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f32_haswell(simsimd_f
     simsimd_f32_t b2_reciprocal = _mm_cvtss_f32(rsqrts);
 
     // Calculate the cosine distance: 1 - ab * a2_reciprocal * b2_reciprocal
-    return 1.0f - ab * a2_reciprocal * b2_reciprocal;
+    simsimd_distance_t result = 1.0f - ab * a2_reciprocal * b2_reciprocal;
+    return result > 0 ? result : 0;
 }
 
 #pragma clang attribute pop
@@ -1189,7 +1193,8 @@ SIMSIMD_INTERNAL simsimd_distance_t _simsimd_cos_normalize_f64_skylake(simsimd_f
 
     simsimd_f64_t a2_reciprocal = _mm_cvtsd_f64(_mm_unpackhi_pd(rsqrts, rsqrts));
     simsimd_f64_t b2_reciprocal = _mm_cvtsd_f64(rsqrts);
-    return 1 - ab * a2_reciprocal * b2_reciprocal;
+    simsimd_distance_t result = 1 - ab * a2_reciprocal * b2_reciprocal;
+    return result > 0 ? result : 0;
 }
 
 SIMSIMD_PUBLIC void simsimd_cos_f32_skylake(simsimd_f32_t const* a, simsimd_f32_t const* b, simsimd_size_t n,

--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -156,7 +156,8 @@ SIMSIMD_PUBLIC void simsimd_cos_f16_sapphire(simsimd_f16_t const* a, simsimd_f16
         } else if (ab == 0) {                                                                                          \
             *result = 1;                                                                                               \
         } else {                                                                                                       \
-            *result = 1 - ab * SIMSIMD_RSQRT(a2) * SIMSIMD_RSQRT(b2);                                                  \
+            simsimd_distance_t unclipped_result = 1 - ab * SIMSIMD_RSQRT(a2) * SIMSIMD_RSQRT(b2);                      \
+            *result = unclipped_result > 0 ? unclipped_result : 0;                                                     \
         }                                                                                                              \
     }
 

--- a/python/test.py
+++ b/python/test.py
@@ -675,6 +675,9 @@ def test_cosine_zero_vector(ndim, dtype):
     result = simd.cosine(b, b)
     assert abs(result) < SIMSIMD_ATOL, f"Expected 0 distance from itself, but got {result}"
 
+    # For the cosine, the output must not be negative!
+    assert np.all(result >= 0), f"Negative result for cosine distance"
+
 
 @pytest.mark.skipif(is_running_under_qemu(), reason="Complex math in QEMU fails")
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")


### PR DESCRIPTION
The new `f64` kernels don't benefit much from NEON, given the small 128-bit register size, but instead leverage the `rsqrt` approximations already used in SimSIMD for lower-precision inputs.