### PR TITLE
Element-wise BLAS-like APIs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,7 @@
         "Logarithmotechnia",
         "maccs",
         "maskz",
+        "musllinux",
         "napi",
         "ndarray",
         "Needleman",
@@ -166,6 +167,7 @@
         "VNNI",
         "vpopcntdq",
         "Wojciech",
+        "wsum",
         "Wunsch",
         "Zilla"
     ],

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SimSIMD provides an alternative.
 
 ## Features
 
-__SimSIMD__ (Arabic: "سيمسيم دي") is a mixed-precision math library of __over 200 SIMD-optimized kernels__ extensively used in AI, Search, and DBMS workloads.
+__SimSIMD__ (Arabic: "سيمسيم دي") is a mixed-precision math library of __over 350 SIMD-optimized kernels__ extensively used in AI, Search, and DBMS workloads.
 Named after the iconic ["Open Sesame"](https://en.wikipedia.org/wiki/Open_sesame) command that opened doors to treasure in _Ali Baba and the Forty Thieves_, SimSimd can help you 10x the cost-efficiency of your computational pipelines.
 Implemented distance functions include:
 
@@ -161,8 +161,7 @@ dist = simsimd.cosine(vec1, vec2, "i8")
 dist = simsimd.cosine(vec1, vec2, "f16")
 dist = simsimd.cosine(vec1, vec2, "f32")
 dist = simsimd.cosine(vec1, vec2, "f64")
-dist = simsimd.hamming(vec1, vec2, "bits")
-dist = simsimd.jaccard(vec1, vec2, "bits")
+dist = simsimd.jaccard(vec1, vec2, "bin8") # Binary vectors with 8-bit words
 ```
 
 It also allows using SimSIMD for half-precision complex numbers, which NumPy does not support.

--- a/c/lib.c
+++ b/c/lib.c
@@ -107,18 +107,31 @@ extern "C" {
         metric(a, b, c, n, result);                                                                             \
     }
 
-#define SIMSIMD_DECLARATION_FMA(name, extension, type)                                                           \
-    SIMSIMD_DYNAMIC void simsimd_##name##_##extension(                                                           \
-        simsimd_##type##_t const *a, simsimd_##type##_t const *b, simsimd_##type##_t const *c, simsimd_size_t n, \
-        simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_##type##_t *result) {                         \
-        static simsimd_kernel_fma_punned_t metric = 0;                                                           \
-        if (metric == 0) {                                                                                       \
-            simsimd_capability_t used_capability;                                                                \
-            simsimd_find_metric_punned(simsimd_metric_##name##_k, simsimd_datatype_##extension##_k,              \
-                                       simsimd_capabilities(), simsimd_cap_any_k,                                \
-                                       (simsimd_metric_punned_t *)(&metric), &used_capability);                  \
-        }                                                                                                        \
-        metric(a, b, c, n, alpha, beta, result);                                                                 \
+#define SIMSIMD_DECLARATION_SCALE(name, extension, type)                                                 \
+    SIMSIMD_DYNAMIC void simsimd_##name##_##extension(simsimd_##type##_t const *a, simsimd_size_t n,     \
+                                                      simsimd_distance_t alpha, simsimd_distance_t beta, \
+                                                      simsimd_##type##_t *result) {                      \
+        static simsimd_kernel_scale_punned_t metric = 0;                                                 \
+        if (metric == 0) {                                                                               \
+            simsimd_capability_t used_capability;                                                        \
+            simsimd_find_metric_punned(simsimd_metric_##name##_k, simsimd_datatype_##extension##_k,      \
+                                       simsimd_capabilities(), simsimd_cap_any_k,                        \
+                                       (simsimd_metric_punned_t *)(&metric), &used_capability);          \
+        }                                                                                                \
+        metric(a, n, alpha, beta, result);                                                               \
+    }
+
+#define SIMSIMD_DECLARATION_SUM(name, extension, type)                                                          \
+    SIMSIMD_DYNAMIC void simsimd_##name##_##extension(simsimd_##type##_t const *a, simsimd_##type##_t const *b, \
+                                                      simsimd_size_t n, simsimd_##type##_t *result) {           \
+        static simsimd_kernel_sum_punned_t metric = 0;                                                          \
+        if (metric == 0) {                                                                                      \
+            simsimd_capability_t used_capability;                                                               \
+            simsimd_find_metric_punned(simsimd_metric_##name##_k, simsimd_datatype_##extension##_k,             \
+                                       simsimd_capabilities(), simsimd_cap_any_k,                               \
+                                       (simsimd_metric_punned_t *)(&metric), &used_capability);                 \
+        }                                                                                                       \
+        metric(a, b, n, result);                                                                                \
     }
 
 #define SIMSIMD_DECLARATION_WSUM(name, extension, type)                                                         \
@@ -133,6 +146,20 @@ extern "C" {
                                        (simsimd_metric_punned_t *)(&metric), &used_capability);                 \
         }                                                                                                       \
         metric(a, b, n, alpha, beta, result);                                                                   \
+    }
+
+#define SIMSIMD_DECLARATION_FMA(name, extension, type)                                                           \
+    SIMSIMD_DYNAMIC void simsimd_##name##_##extension(                                                           \
+        simsimd_##type##_t const *a, simsimd_##type##_t const *b, simsimd_##type##_t const *c, simsimd_size_t n, \
+        simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_##type##_t *result) {                         \
+        static simsimd_kernel_fma_punned_t metric = 0;                                                           \
+        if (metric == 0) {                                                                                       \
+            simsimd_capability_t used_capability;                                                                \
+            simsimd_find_metric_punned(simsimd_metric_##name##_k, simsimd_datatype_##extension##_k,              \
+                                       simsimd_capabilities(), simsimd_cap_any_k,                                \
+                                       (simsimd_metric_punned_t *)(&metric), &used_capability);                  \
+        }                                                                                                        \
+        metric(a, b, c, n, alpha, beta, result);                                                                 \
     }
 
 // Dot products
@@ -200,18 +227,30 @@ SIMSIMD_DECLARATION_CURVED(bilinear, bf16, bf16)
 SIMSIMD_DECLARATION_CURVED(mahalanobis, bf16, bf16)
 
 // Element-wise operations
-SIMSIMD_DECLARATION_FMA(fma, f64, f64)
-SIMSIMD_DECLARATION_FMA(fma, f32, f32)
-SIMSIMD_DECLARATION_FMA(fma, f16, f16)
-SIMSIMD_DECLARATION_FMA(fma, bf16, bf16)
-SIMSIMD_DECLARATION_FMA(fma, i8, i8)
-SIMSIMD_DECLARATION_FMA(fma, u8, u8)
+SIMSIMD_DECLARATION_SUM(sum, f64, f64)
+SIMSIMD_DECLARATION_SUM(sum, f32, f32)
+SIMSIMD_DECLARATION_SUM(sum, f16, f16)
+SIMSIMD_DECLARATION_SUM(sum, bf16, bf16)
+SIMSIMD_DECLARATION_SUM(sum, i8, i8)
+SIMSIMD_DECLARATION_SUM(sum, u8, u8)
+SIMSIMD_DECLARATION_SCALE(scale, f64, f64)
+SIMSIMD_DECLARATION_SCALE(scale, f32, f32)
+SIMSIMD_DECLARATION_SCALE(scale, f16, f16)
+SIMSIMD_DECLARATION_SCALE(scale, bf16, bf16)
+SIMSIMD_DECLARATION_SCALE(scale, i8, i8)
+SIMSIMD_DECLARATION_SCALE(scale, u8, u8)
 SIMSIMD_DECLARATION_WSUM(wsum, f64, f64)
 SIMSIMD_DECLARATION_WSUM(wsum, f32, f32)
 SIMSIMD_DECLARATION_WSUM(wsum, f16, f16)
 SIMSIMD_DECLARATION_WSUM(wsum, bf16, bf16)
 SIMSIMD_DECLARATION_WSUM(wsum, i8, i8)
 SIMSIMD_DECLARATION_WSUM(wsum, u8, u8)
+SIMSIMD_DECLARATION_FMA(fma, f64, f64)
+SIMSIMD_DECLARATION_FMA(fma, f32, f32)
+SIMSIMD_DECLARATION_FMA(fma, f16, f16)
+SIMSIMD_DECLARATION_FMA(fma, bf16, bf16)
+SIMSIMD_DECLARATION_FMA(fma, i8, i8)
+SIMSIMD_DECLARATION_FMA(fma, u8, u8)
 
 SIMSIMD_DYNAMIC int simsimd_uses_neon(void) { return (simsimd_capabilities() & simsimd_cap_neon_k) != 0; }
 SIMSIMD_DYNAMIC int simsimd_uses_neon_f16(void) { return (simsimd_capabilities() & simsimd_cap_neon_f16_k) != 0; }
@@ -310,6 +349,17 @@ SIMSIMD_DYNAMIC simsimd_capability_t simsimd_capabilities(void) {
     simsimd_mahalanobis_bf16((simsimd_bf16_t *)x, (simsimd_bf16_t *)x, (simsimd_bf16_t *)x, 0, dummy_results);
 
     // Elementwise
+    simsimd_sum_f64((simsimd_f64_t *)x, (simsimd_f64_t *)x, 0, (simsimd_f64_t *)x);
+    simsimd_sum_f32((simsimd_f32_t *)x, (simsimd_f32_t *)x, 0, (simsimd_f32_t *)x);
+    simsimd_sum_f16((simsimd_f16_t *)x, (simsimd_f16_t *)x, 0, (simsimd_f16_t *)x);
+    simsimd_sum_bf16((simsimd_bf16_t *)x, (simsimd_bf16_t *)x, 0, (simsimd_bf16_t *)x);
+    simsimd_sum_i8((simsimd_i8_t *)x, (simsimd_i8_t *)x, 0, (simsimd_i8_t *)x);
+    simsimd_sum_u8((simsimd_u8_t *)x, (simsimd_u8_t *)x, 0, (simsimd_u8_t *)x);
+    simsimd_scale_f64((simsimd_f64_t *)x, 0, 0, 0, (simsimd_f64_t *)x);
+    simsimd_scale_f32((simsimd_f32_t *)x, 0, 0, 0, (simsimd_f32_t *)x);
+    simsimd_scale_f16((simsimd_f16_t *)x, 0, 0, 0, (simsimd_f16_t *)x);
+    simsimd_scale_bf16((simsimd_bf16_t *)x, 0, 0, 0, (simsimd_bf16_t *)x);
+    simsimd_scale_i8((simsimd_i8_t *)x, 0, 0, 0, (simsimd_i8_t *)x);
     simsimd_wsum_f64((simsimd_f64_t *)x, (simsimd_f64_t *)x, 0, 0, 0, (simsimd_f64_t *)x);
     simsimd_wsum_f32((simsimd_f32_t *)x, (simsimd_f32_t *)x, 0, 0, 0, (simsimd_f32_t *)x);
     simsimd_wsum_f16((simsimd_f16_t *)x, (simsimd_f16_t *)x, 0, 0, 0, (simsimd_f16_t *)x);

--- a/include/simsimd/elementwise.h
+++ b/include/simsimd/elementwise.h
@@ -5,8 +5,8 @@
  *  @date       October 16, 2024
  *
  *  Contains following element-wise operations:
+ *  - Scale (Multiply) with Shift: R[i] = Alpha * A[i] + Beta
  *  - Sum (Add): R[i] = A[i] + B[i]
- *  - Scale (Multiply): R[i] = Alpha * A[i]
  *  - WSum or Weighted-Sum: R[i] = Alpha * A[i] + Beta * B[i]
  *  - FMA or Fused-Multiply-Add: R[i] = Alpha * A[i] * B[i] + Beta * C[i]
  *
@@ -36,8 +36,8 @@
  *  x86 intrinsics: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/
  *  Arm intrinsics: https://developer.arm.com/architectures/instruction-sets/intrinsics/
  */
-#ifndef SIMSIMD_FMA_H
-#define SIMSIMD_FMA_H
+#ifndef SIMSIMD_ELEMENTWISE_H
+#define SIMSIMD_ELEMENTWISE_H
 
 #include "types.h"
 
@@ -45,76 +45,223 @@
 extern "C" {
 #endif
 
+// clang-format off
+
 /*  Serial backends for all numeric types.
  *  By default they use 32-bit arithmetic, unless the arguments themselves contain 64-bit floats.
  *  For double-precision computation check out the "*_accurate" variants of those "*_serial" functions.
  */
-SIMSIMD_PUBLIC void simsimd_wsum_f64_serial(                          //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f32_serial(                          //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f16_serial(                          //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_bf16_serial(                           //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_i8_serial(                         //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_u8_serial(                         //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f64_serial(simsimd_f64_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f32_serial(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f16_serial(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_bf16_serial(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_i8_serial(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_u8_serial(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
 
-SIMSIMD_PUBLIC void simsimd_fma_f64_serial(                                                   //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f32_serial(                                                   //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f16_serial(                                                   //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_bf16_serial(                                                     //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_i8_serial(                                                 //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_u8_serial(                                                 //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f64_serial(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f32_serial(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f16_serial(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_bf16_serial(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_i8_serial(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_u8_serial(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_u8_t *result);
 
-#define SIMSIMD_MAKE_WSUM(name, input_type, accumulator_type, load_and_convert, convert_and_store)   \
-    SIMSIMD_PUBLIC void simsimd_wsum_##input_type##_##name(                                          \
-        simsimd_##input_type##_t const *a, simsimd_##input_type##_t const *b, simsimd_size_t n,      \
-        simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_##input_type##_t *result) {       \
-        for (simsimd_size_t i = 0; i != n; ++i) {                                                    \
-            simsimd_##accumulator_type##_t ai = load_and_convert(a + i);                             \
-            simsimd_##accumulator_type##_t bi = load_and_convert(b + i);                             \
-            simsimd_##accumulator_type##_t ai_scaled = (simsimd_##accumulator_type##_t)(ai * alpha); \
-            simsimd_##accumulator_type##_t bi_scaled = (simsimd_##accumulator_type##_t)(bi * beta);  \
-            simsimd_##accumulator_type##_t sum = ai_scaled + bi_scaled;                              \
-            convert_and_store(sum, result + i);                                                      \
-        }                                                                                            \
+SIMSIMD_PUBLIC void simsimd_wsum_f64_serial(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f32_serial(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f16_serial(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_bf16_serial(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_i8_serial(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_u8_serial(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_fma_f64_serial(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f32_serial(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f16_serial(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_bf16_serial(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_i8_serial(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_u8_serial(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+/*  SIMD-powered backends for Arm NEON, mostly using 32-bit arithmetic over 128-bit words.
+ *  By far the most portable backend, covering most Arm v8 devices, over a billion phones, and almost all
+ *  server CPUs produced before 2023.
+ */
+SIMSIMD_PUBLIC void simsimd_scale_f32_neon(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f16_neon(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_bf16_neon(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_u8_neon(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_i8_neon(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_sum_f32_neon(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f16_neon(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_bf16_neon(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_u8_neon(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_i8_neon(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_i8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_wsum_f32_neon(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f16_neon(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_bf16_neon(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_u8_neon(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_i8_neon(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_fma_f32_neon(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f16_neon(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_bf16_neon(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_u8_neon(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_i8_neon(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+
+/*  SIMD-powered backends for AVX2 CPUs of Haswell generation and newer, using 32-bit arithmetic over 256-bit words.
+ *  First demonstrated in 2011, at least one Haswell-based processor was still being sold in 2022 — the Pentium G3420.
+ *  Practically all modern x86 CPUs support AVX2, FMA, and F16C, making it a perfect baseline for SIMD algorithms.
+ *  On other hand, there is no need to implement AVX2 versions of `f32` and `f64` functions, as those are
+ *  properly vectorized by recent compilers.
+ */
+SIMSIMD_PUBLIC void simsimd_scale_f64_haswell(simsimd_f64_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f32_haswell(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_f16_haswell(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_bf16_haswell(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_i8_haswell(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_u8_haswell(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_sum_f64_haswell(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f32_haswell(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f16_haswell(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_bf16_haswell(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_i8_haswell(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_u8_haswell(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_wsum_f64_haswell(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f32_haswell(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f16_haswell(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_bf16_haswell(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_i8_haswell(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_u8_haswell(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_fma_f64_haswell(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f32_haswell(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f16_haswell(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_bf16_haswell(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_i8_haswell(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_u8_haswell(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+/*  SIMD-powered backends for various generations of AVX512 CPUs.
+ *  Unlike the distance metrics, the SIMD implementation of FMA and WSum benefits from aligned stores.
+ *  Assuming the size of ZMM register matches the width of the cache line, we skip the unaligned head
+ *  and tail of the output buffer, and only use aligned stores in the main loop.
+ */
+SIMSIMD_PUBLIC void simsimd_scale_f16_sapphire(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_i8_sapphire(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_u8_sapphire(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_sum_f64_skylake(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_f32_skylake(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_bf16_skylake(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_bf16_t *result);
+
+SIMSIMD_PUBLIC void simsimd_wsum_f64_skylake(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_f32_skylake(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_bf16_skylake(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+
+SIMSIMD_PUBLIC void simsimd_fma_f64_skylake(simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_f32_skylake(simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_bf16_skylake(simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
+
+SIMSIMD_PUBLIC void simsimd_scale_f16_sapphire(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_i8_sapphire(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_scale_u8_sapphire(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_sum_f16_sapphire(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_i8_sapphire(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_sum_u8_sapphire(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_wsum_f16_sapphire(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_i8_sapphire(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_wsum_u8_sapphire(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+SIMSIMD_PUBLIC void simsimd_fma_f16_sapphire(simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_i8_sapphire(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
+SIMSIMD_PUBLIC void simsimd_fma_u8_sapphire(simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
+
+// clang-format on
+
+#define SIMSIMD_MAKE_SCALE(name, input_type, accumulator_type, load_and_convert, convert_and_store)              \
+    SIMSIMD_PUBLIC void simsimd_scale_##input_type##_##name(simsimd_##input_type##_t const *a, simsimd_size_t n, \
+                                                            simsimd_distance_t alpha, simsimd_distance_t beta,   \
+                                                            simsimd_##input_type##_t *result) {                  \
+        simsimd_##accumulator_type##_t alpha_cast = (simsimd_##accumulator_type##_t)alpha;                       \
+        simsimd_##accumulator_type##_t beta_cast = (simsimd_##accumulator_type##_t)beta;                         \
+        for (simsimd_size_t i = 0; i != n; ++i) {                                                                \
+            simsimd_##accumulator_type##_t ai = load_and_convert(a + i);                                         \
+            simsimd_##accumulator_type##_t sum = (simsimd_##accumulator_type##_t)(alpha_cast * ai + beta_cast);  \
+            convert_and_store(sum, result + i);                                                                  \
+        }                                                                                                        \
+    }
+#define SIMSIMD_MAKE_SUM(name, input_type, accumulator_type, load_and_convert, convert_and_store)              \
+    SIMSIMD_PUBLIC void simsimd_sum_##input_type##_##name(simsimd_##input_type##_t const *a,                   \
+                                                          simsimd_##input_type##_t const *b, simsimd_size_t n, \
+                                                          simsimd_##input_type##_t *result) {                  \
+        for (simsimd_size_t i = 0; i != n; ++i) {                                                              \
+            simsimd_##accumulator_type##_t ai = load_and_convert(a + i);                                       \
+            simsimd_##accumulator_type##_t bi = load_and_convert(b + i);                                       \
+            simsimd_##accumulator_type##_t sum = ai + bi;                                                      \
+            convert_and_store(sum, result + i);                                                                \
+        }                                                                                                      \
+    }
+
+#define SIMSIMD_MAKE_WSUM(name, input_type, accumulator_type, load_and_convert, convert_and_store)        \
+    SIMSIMD_PUBLIC void simsimd_wsum_##input_type##_##name(                                               \
+        simsimd_##input_type##_t const *a, simsimd_##input_type##_t const *b, simsimd_size_t n,           \
+        simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_##input_type##_t *result) {            \
+        simsimd_##accumulator_type##_t alpha_cast = (simsimd_##accumulator_type##_t)alpha;                \
+        simsimd_##accumulator_type##_t beta_cast = (simsimd_##accumulator_type##_t)beta;                  \
+        for (simsimd_size_t i = 0; i != n; ++i) {                                                         \
+            simsimd_##accumulator_type##_t ai = load_and_convert(a + i);                                  \
+            simsimd_##accumulator_type##_t bi = load_and_convert(b + i);                                  \
+            simsimd_##accumulator_type##_t ai_scaled = (simsimd_##accumulator_type##_t)(ai * alpha_cast); \
+            simsimd_##accumulator_type##_t bi_scaled = (simsimd_##accumulator_type##_t)(bi * beta_cast);  \
+            simsimd_##accumulator_type##_t sum = ai_scaled + bi_scaled;                                   \
+            convert_and_store(sum, result + i);                                                           \
+        }                                                                                                 \
     }
 
 #define SIMSIMD_MAKE_FMA(name, input_type, accumulator_type, load_and_convert, convert_and_store)                \
     SIMSIMD_PUBLIC void simsimd_fma_##input_type##_##name(                                                       \
         simsimd_##input_type##_t const *a, simsimd_##input_type##_t const *b, simsimd_##input_type##_t const *c, \
         simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_##input_type##_t *result) { \
+        simsimd_##accumulator_type##_t alpha_cast = (simsimd_##accumulator_type##_t)alpha;                       \
+        simsimd_##accumulator_type##_t beta_cast = (simsimd_##accumulator_type##_t)beta;                         \
         for (simsimd_size_t i = 0; i != n; ++i) {                                                                \
             simsimd_##accumulator_type##_t ai = load_and_convert(a + i);                                         \
             simsimd_##accumulator_type##_t bi = load_and_convert(b + i);                                         \
             simsimd_##accumulator_type##_t ci = load_and_convert(c + i);                                         \
-            simsimd_##accumulator_type##_t abi_scaled = (simsimd_##accumulator_type##_t)(ai * bi * alpha);       \
-            simsimd_##accumulator_type##_t ci_scaled = (simsimd_##accumulator_type##_t)(ci * beta);              \
+            simsimd_##accumulator_type##_t abi_scaled = (simsimd_##accumulator_type##_t)(ai * bi * alpha_cast);  \
+            simsimd_##accumulator_type##_t ci_scaled = (simsimd_##accumulator_type##_t)(ci * beta_cast);         \
             simsimd_##accumulator_type##_t sum = abi_scaled + ci_scaled;                                         \
             convert_and_store(sum, result + i);                                                                  \
         }                                                                                                        \
     }
+
+SIMSIMD_MAKE_SCALE(serial, f64, f64, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_scale_f64_serial
+SIMSIMD_MAKE_SCALE(serial, f32, f32, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_scale_f32_serial
+SIMSIMD_MAKE_SCALE(serial, f16, f32, SIMSIMD_F16_TO_F32, SIMSIMD_F32_TO_F16)    // simsimd_scale_f16_serial
+SIMSIMD_MAKE_SCALE(serial, bf16, f32, SIMSIMD_BF16_TO_F32, SIMSIMD_F32_TO_BF16) // simsimd_scale_bf16_serial
+SIMSIMD_MAKE_SCALE(serial, i8, f32, SIMSIMD_DEREFERENCE, SIMSIMD_F32_TO_I8)     // simsimd_scale_i8_serial
+SIMSIMD_MAKE_SCALE(serial, u8, f32, SIMSIMD_DEREFERENCE, SIMSIMD_F32_TO_U8)     // simsimd_scale_u8_serial
+
+SIMSIMD_MAKE_SCALE(accurate, f32, f64, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_scale_f32_accurate
+SIMSIMD_MAKE_SCALE(accurate, f16, f64, SIMSIMD_F16_TO_F32, SIMSIMD_F32_TO_F16)    // simsimd_scale_f16_accurate
+SIMSIMD_MAKE_SCALE(accurate, bf16, f64, SIMSIMD_BF16_TO_F32, SIMSIMD_F32_TO_BF16) // simsimd_scale_bf16_accurate
+SIMSIMD_MAKE_SCALE(accurate, i8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_I8)     // simsimd_scale_i8_accurate
+SIMSIMD_MAKE_SCALE(accurate, u8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_U8)     // simsimd_scale_u8_accurate
+
+SIMSIMD_MAKE_SUM(serial, f64, f64, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_sum_f64_serial
+SIMSIMD_MAKE_SUM(serial, f32, f32, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_sum_f32_serial
+SIMSIMD_MAKE_SUM(serial, f16, f32, SIMSIMD_F16_TO_F32, SIMSIMD_F32_TO_F16)    // simsimd_sum_f16_serial
+SIMSIMD_MAKE_SUM(serial, bf16, f32, SIMSIMD_BF16_TO_F32, SIMSIMD_F32_TO_BF16) // simsimd_sum_bf16_serial
+SIMSIMD_MAKE_SUM(serial, i8, f32, SIMSIMD_DEREFERENCE, SIMSIMD_F32_TO_I8)     // simsimd_sum_i8_serial
+SIMSIMD_MAKE_SUM(serial, u8, f32, SIMSIMD_DEREFERENCE, SIMSIMD_F32_TO_U8)     // simsimd_sum_u8_serial
+
+SIMSIMD_MAKE_SUM(accurate, f32, f64, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_sum_f32_accurate
+SIMSIMD_MAKE_SUM(accurate, f16, f64, SIMSIMD_F16_TO_F32, SIMSIMD_F32_TO_F16)    // simsimd_sum_f16_accurate
+SIMSIMD_MAKE_SUM(accurate, bf16, f64, SIMSIMD_BF16_TO_F32, SIMSIMD_F32_TO_BF16) // simsimd_sum_bf16_accurate
+SIMSIMD_MAKE_SUM(accurate, i8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_I8)     // simsimd_sum_i8_accurate
+SIMSIMD_MAKE_SUM(accurate, u8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_U8)     // simsimd_sum_u8_accurate
 
 SIMSIMD_MAKE_WSUM(serial, f64, f64, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_wsum_f64_serial
 SIMSIMD_MAKE_WSUM(serial, f32, f32, SIMSIMD_DEREFERENCE, SIMSIMD_EXPORT)       // simsimd_wsum_f32_serial
@@ -141,130 +288,6 @@ SIMSIMD_MAKE_FMA(accurate, f16, f64, SIMSIMD_F16_TO_F32, SIMSIMD_F32_TO_F16)    
 SIMSIMD_MAKE_FMA(accurate, bf16, f64, SIMSIMD_BF16_TO_F32, SIMSIMD_F32_TO_BF16) // simsimd_fma_bf16_accurate
 SIMSIMD_MAKE_FMA(accurate, i8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_I8)     // simsimd_fma_i8_accurate
 SIMSIMD_MAKE_FMA(accurate, u8, f64, SIMSIMD_DEREFERENCE, SIMSIMD_F64_TO_U8)     // simsimd_fma_u8_accurate
-
-/*  SIMD-powered backends for Arm NEON, mostly using 32-bit arithmetic over 128-bit words.
- *  By far the most portable backend, covering most Arm v8 devices, over a billion phones, and almost all
- *  server CPUs produced before 2023.
- */
-SIMSIMD_PUBLIC void simsimd_wsum_f32_neon(                            //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f16_neon(                            //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_bf16_neon(                             //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_u8_neon(                           //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_i8_neon(                           //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-
-SIMSIMD_PUBLIC void simsimd_fma_f32_neon(                                   //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, //
-    simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f16_neon(                                   //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, //
-    simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_bf16_neon(                                     //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, //
-    simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_u8_neon(                                 //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, //
-    simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_i8_neon(                                 //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, //
-    simsimd_size_t n, simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-
-/*  SIMD-powered backends for AVX2 CPUs of Haswell generation and newer, using 32-bit arithmetic over 256-bit words.
- *  First demonstrated in 2011, at least one Haswell-based processor was still being sold in 2022 — the Pentium G3420.
- *  Practically all modern x86 CPUs support AVX2, FMA, and F16C, making it a perfect baseline for SIMD algorithms.
- *  On other hand, there is no need to implement AVX2 versions of `f32` and `f64` functions, as those are
- *  properly vectorized by recent compilers.
- */
-SIMSIMD_PUBLIC void simsimd_wsum_f64_haswell(                         //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f32_haswell(                         //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f16_haswell(                         //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_bf16_haswell(                          //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_i8_haswell(                        //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_u8_haswell(                        //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f64_haswell(                                                  //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f32_haswell(                                                  //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f16_haswell(                                                  //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_bf16_haswell(                                                    //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_i8_haswell(                                                //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_u8_haswell(                                                //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
-
-/*  SIMD-powered backends for various generations of AVX512 CPUs.
- *  Unlike the distance metrics, the SIMD implementation of FMA and WSum benefits from aligned stores.
- *  Assuming the size of ZMM register matches the width of the cache line, we skip the unaligned head
- *  and tail of the output buffer, and only use aligned stores in the main loop.
- */
-SIMSIMD_PUBLIC void simsimd_wsum_f64_skylake(                         //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_f32_skylake(                         //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_bf16_skylake(                          //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-
-SIMSIMD_PUBLIC void simsimd_fma_f64_skylake(                                                  //
-    simsimd_f64_t const *a, simsimd_f64_t const *b, simsimd_f64_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f64_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_f32_skylake(                                                  //
-    simsimd_f32_t const *a, simsimd_f32_t const *b, simsimd_f32_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f32_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_bf16_skylake(                                                    //
-    simsimd_bf16_t const *a, simsimd_bf16_t const *b, simsimd_bf16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_bf16_t *result);
-
-SIMSIMD_PUBLIC void simsimd_wsum_f16_sapphire(                        //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_i8_sapphire(                       //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_wsum_u8_sapphire(                       //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
-
-SIMSIMD_PUBLIC void simsimd_fma_f16_sapphire(                                                 //
-    simsimd_f16_t const *a, simsimd_f16_t const *b, simsimd_f16_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_f16_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_i8_sapphire(                                               //
-    simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_i8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_i8_t *result);
-SIMSIMD_PUBLIC void simsimd_fma_u8_sapphire(                                               //
-    simsimd_u8_t const *a, simsimd_u8_t const *b, simsimd_u8_t const *c, simsimd_size_t n, //
-    simsimd_distance_t alpha, simsimd_distance_t beta, simsimd_u8_t *result);
 
 #if _SIMSIMD_TARGET_X86
 #if SIMSIMD_TARGET_HASWELL
@@ -320,8 +343,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f32_haswell(                         //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f32_haswell(a, n, alpha, result); }
-        else { simsimd_scale_f32_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f32_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_f32_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -389,8 +412,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f64_haswell(                         //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f64_haswell(a, n, alpha, result); }
-        else { simsimd_scale_f64_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f64_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_f64_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -474,8 +497,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f16_haswell(                         //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f16_haswell(a, n, alpha, result); }
-        else { simsimd_scale_f16_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f16_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_f16_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -568,8 +591,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_bf16_haswell(                          //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_bf16_haswell(a, n, alpha, result); }
-        else { simsimd_scale_bf16_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_bf16_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_bf16_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -796,8 +819,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_i8_haswell(                        //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_i8_haswell(a, n, alpha, result); }
-        else { simsimd_scale_i8_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_i8_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_i8_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -925,8 +948,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_u8_haswell(                        //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_u8_haswell(a, n, alpha, result); }
-        else { simsimd_scale_u8_haswell(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_u8_haswell(a, n, alpha, 0, result); }
+        else { simsimd_scale_u8_haswell(b, n, beta, 0, result); }
         return;
     }
 
@@ -1154,8 +1177,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f64_skylake(                         //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f64_skylake(a, n, alpha, result); }
-        else { simsimd_scale_f64_skylake(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f64_skylake(a, n, alpha, 0, result); }
+        else { simsimd_scale_f64_skylake(b, n, beta, 0, result); }
         return;
     }
 
@@ -1242,8 +1265,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f32_skylake(                         //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f32_skylake(a, n, alpha, result); }
-        else { simsimd_scale_f32_skylake(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f32_skylake(a, n, alpha, 0, result); }
+        else { simsimd_scale_f32_skylake(b, n, beta, 0, result); }
         return;
     }
 
@@ -1335,8 +1358,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_bf16_skylake(                          //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_bf16_skylake(a, n, alpha, result); }
-        else { simsimd_scale_bf16_skylake(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_bf16_skylake(a, n, alpha, 0, result); }
+        else { simsimd_scale_bf16_skylake(b, n, beta, 0, result); }
         return;
     }
 
@@ -1533,8 +1556,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f16_sapphire(                        //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f16_sapphire(a, n, alpha, result); }
-        else { simsimd_scale_f16_sapphire(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f16_sapphire(a, n, alpha, 0, result); }
+        else { simsimd_scale_f16_sapphire(b, n, beta, 0, result); }
         return;
     }
 
@@ -1663,8 +1686,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_u8_sapphire(                       //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_u8_sapphire(a, n, alpha, result); }
-        else { simsimd_scale_u8_sapphire(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_u8_sapphire(a, n, alpha, 0, result); }
+        else { simsimd_scale_u8_sapphire(b, n, beta, 0, result); }
         return;
     }
 
@@ -1784,8 +1807,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_i8_sapphire(                       //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_i8_sapphire(a, n, alpha, result); }
-        else { simsimd_scale_i8_sapphire(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_i8_sapphire(a, n, alpha, 0, result); }
+        else { simsimd_scale_i8_sapphire(b, n, beta, 0, result); }
         return;
     }
 
@@ -1963,19 +1986,22 @@ SIMSIMD_PUBLIC void simsimd_sum_f32_neon(simsimd_f32_t const *a, simsimd_f32_t c
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f32_neon(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                           simsimd_f32_t *result) {
+                                           simsimd_distance_t beta, simsimd_f32_t *result) {
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
+    float32x4_t alpha_vec = vdupq_n_f32(alpha_f32);
+    float32x4_t beta_vec = vdupq_n_f32(beta_f32);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 4 <= n; i += 4) {
         float32x4_t a_vec = vld1q_f32(a + i);
-        float32x4_t sum_vec = vmulq_n_f32(a_vec, alpha_f32);
+        float32x4_t sum_vec = vfmaq_n_f32(beta_vec, a_vec, alpha_f32);
         vst1q_f32(result + i, sum_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) result[i] = alpha_f32 * a[i];
+    for (; i < n; ++i) result[i] = alpha_f32 * a[i] + beta_f32;
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_f32_neon(                            //
@@ -1992,8 +2018,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f32_neon(                            //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f32_neon(a, n, alpha, result); }
-        else { simsimd_scale_f32_neon(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f32_neon(a, n, alpha, 0, result); }
+        else { simsimd_scale_f32_neon(b, n, beta, 0, result); }
         return;
     }
 
@@ -2063,19 +2089,22 @@ SIMSIMD_PUBLIC void simsimd_sum_bf16_neon(simsimd_bf16_t const *a, simsimd_bf16_
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_bf16_neon(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                            simsimd_bf16_t *result) {
+                                            simsimd_distance_t beta, simsimd_bf16_t *result) {
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
+    float32x4_t alpha_vec = vdupq_n_f32(alpha_f32);
+    float32x4_t beta_vec = vdupq_n_f32(beta_f32);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 4 <= n; i += 4) {
         float32x4_t a_vec = vcvt_f32_bf16(vld1_bf16((bfloat16_t const *)a + i));
-        float32x4_t sum_vec = vmulq_n_f32(a_vec, alpha_f32);
+        float32x4_t sum_vec = vfmaq_f32(beta_vec, a_vec, alpha_vec);
         vst1_bf16((bfloat16_t *)result + i, vcvt_bf16_f32(sum_vec));
     }
 
     // The tail:
-    for (; i < n; ++i) simsimd_f32_to_bf16(alpha_f32 * simsimd_bf16_to_f32(a + i), result + i);
+    for (; i < n; ++i) simsimd_f32_to_bf16(alpha_f32 * simsimd_bf16_to_f32(a + i) + beta_f32, result + i);
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_bf16_neon(                             //
@@ -2092,8 +2121,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_bf16_neon(                             //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_bf16_neon(a, n, alpha, result); }
-        else { simsimd_scale_bf16_neon(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_bf16_neon(a, n, alpha, 0, result); }
+        else { simsimd_scale_bf16_neon(b, n, beta, 0, result); }
         return;
     }
 
@@ -2167,19 +2196,22 @@ SIMSIMD_PUBLIC void simsimd_sum_f16_neon(simsimd_f16_t const *a, simsimd_f16_t c
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f16_neon(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                           simsimd_f16_t *result) {
+                                           simsimd_distance_t beta, simsimd_f16_t *result) {
     float16_t alpha_f16 = (float16_t)alpha;
+    float16_t beta_f16 = (float16_t)beta;
+    float16x8_t alpha_vec = vdupq_n_f16(alpha_f16);
+    float16x8_t beta_vec = vdupq_n_f16(beta_f16);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 8 <= n; i += 8) {
         float16x8_t a_vec = vld1q_f16((float16_t const *)a + i);
-        float16x8_t sum_vec = vmulq_n_f16(a_vec, alpha_f16);
+        float16x8_t sum_vec = vfmaq_f16(beta_vec, a_vec, alpha_vec);
         vst1q_f16((float16_t *)result + i, sum_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) ((float16_t *)result)[i] = alpha_f16 * ((float16_t const *)a)[i];
+    for (; i < n; ++i) ((float16_t *)result)[i] = alpha_f16 * ((float16_t const *)a)[i] + beta_f16;
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_f16_neon(                            //
@@ -2195,8 +2227,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_f16_neon(                            //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_f16_neon(a, n, alpha, result); }
-        else { simsimd_scale_f16_neon(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_f16_neon(a, n, alpha, 0, result); }
+        else { simsimd_scale_f16_neon(b, n, beta, 0, result); }
         return;
     }
 
@@ -2260,21 +2292,24 @@ SIMSIMD_PUBLIC void simsimd_sum_u8_neon(simsimd_u8_t const *a, simsimd_u8_t cons
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_u8_neon(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                          simsimd_u8_t *result) {
+                                          simsimd_distance_t beta, simsimd_u8_t *result) {
     float16_t alpha_f16 = (float16_t)alpha;
+    float16_t beta_f16 = (float16_t)beta;
+    float16x8_t alpha_vec = vdupq_n_f16(alpha_f16);
+    float16x8_t beta_vec = vdupq_n_f16(beta_f16);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 8 <= n; i += 8) {
         uint8x8_t a_u8_vec = vld1_u8(a + i);
         float16x8_t a_vec = vcvtq_f16_u16(vmovl_u8(a_u8_vec));
-        float16x8_t sum_vec = vmulq_n_f16(a_vec, alpha_f16);
+        float16x8_t sum_vec = vfmaq_f16(beta_vec, a_vec, alpha_vec);
         uint8x8_t sum_u8_vec = vqmovn_u16(vcvtaq_u16_f16(sum_vec));
         vst1_u8(result + i, sum_u8_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) { SIMSIMD_F32_TO_U8(alpha_f16 * a[i], result + i); }
+    for (; i < n; ++i) { SIMSIMD_F32_TO_U8(alpha_f16 * a[i] + beta_f16, result + i); }
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_u8_neon(                           //
@@ -2291,8 +2326,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_u8_neon(                           //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_u8_neon(a, n, alpha, result); }
-        else { simsimd_scale_u8_neon(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_u8_neon(a, n, alpha, 0, result); }
+        else { simsimd_scale_u8_neon(b, n, beta, 0, result); }
         return;
     }
 
@@ -2360,21 +2395,24 @@ SIMSIMD_PUBLIC void simsimd_sum_i8_neon(simsimd_i8_t const *a, simsimd_i8_t cons
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_i8_neon(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                          simsimd_i8_t *result) {
+                                          simsimd_distance_t beta, simsimd_i8_t *result) {
     float16_t alpha_f16 = (float16_t)alpha;
+    float16_t beta_f16 = (float16_t)beta;
+    float16x8_t alpha_vec = vdupq_n_f16(alpha_f16);
+    float16x8_t beta_vec = vdupq_n_f16(beta_f16);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 8 <= n; i += 8) {
         int8x8_t a_i8_vec = vld1_s8(a + i);
         float16x8_t a_vec = vcvtq_f16_s16(vmovl_s8(a_i8_vec));
-        float16x8_t sum_vec = vmulq_n_f16(a_vec, alpha_f16);
+        float16x8_t sum_vec = vfmaq_f16(beta_vec, a_vec, alpha_vec);
         int8x8_t sum_i8_vec = vqmovn_s16(vcvtaq_s16_f16(sum_vec));
         vst1_s8(result + i, sum_i8_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) { SIMSIMD_F32_TO_I8(alpha_f16 * a[i], result + i); }
+    for (; i < n; ++i) { SIMSIMD_F32_TO_I8(alpha_f16 * a[i] + beta_f16, result + i); }
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_i8_neon(                           //
@@ -2391,8 +2429,8 @@ SIMSIMD_PUBLIC void simsimd_wsum_i8_neon(                           //
     // 2. Just scaling, when one of the weights is equal to zero.
     else if (alpha == 0 || beta == 0) {
         // In this case we can avoid half of the load instructions.
-        if (beta == 0) { simsimd_scale_i8_neon(a, n, alpha, result); }
-        else { simsimd_scale_i8_neon(b, n, beta, result); }
+        if (beta == 0) { simsimd_scale_i8_neon(a, n, alpha, 0, result); }
+        else { simsimd_scale_i8_neon(b, n, beta, 0, result); }
         return;
     }
 

--- a/include/simsimd/elementwise.h
+++ b/include/simsimd/elementwise.h
@@ -311,20 +311,22 @@ SIMSIMD_PUBLIC void simsimd_sum_f32_haswell(simsimd_f32_t const *a, simsimd_f32_
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f32_haswell(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_f32_t *result) {
+                                              simsimd_distance_t beta, simsimd_f32_t *result) {
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
+    __m256 beta_vec = _mm256_set1_ps(beta_f32);
     __m256 alpha_vec = _mm256_set1_ps(alpha_f32);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 8 <= n; i += 8) {
         __m256 a_vec = _mm256_loadu_ps(a + i);
-        __m256 sum_vec = _mm256_mul_ps(a_vec, alpha_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(a_vec, alpha_vec, beta_vec);
         _mm256_storeu_ps(result + i, sum_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) result[i] = alpha_f32 * a[i];
+    for (; i < n; ++i) result[i] = alpha_f32 * a[i] + beta_f32;
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_f32_haswell(                         //
@@ -358,8 +360,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_f32_haswell(                         //
         __m256 a_vec = _mm256_loadu_ps(a + i);
         __m256 b_vec = _mm256_loadu_ps(b + i);
         __m256 a_scaled_vec = _mm256_mul_ps(a_vec, alpha_vec);
-        __m256 b_scaled_vec = _mm256_mul_ps(b_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(a_scaled_vec, b_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(b_vec, beta_vec, a_scaled_vec);
         _mm256_storeu_ps(result + i, sum_vec);
     }
 
@@ -383,19 +384,20 @@ SIMSIMD_PUBLIC void simsimd_sum_f64_haswell(simsimd_f64_t const *a, simsimd_f64_
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f64_haswell(simsimd_f64_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_f64_t *result) {
+                                              simsimd_distance_t beta, simsimd_f64_t *result) {
     __m256d alpha_vec = _mm256_set1_pd(alpha);
+    __m256d beta_vec = _mm256_set1_pd(beta);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 4 <= n; i += 4) {
         __m256d a_vec = _mm256_loadu_pd(a + i);
-        __m256d sum_vec = _mm256_mul_pd(a_vec, alpha_vec);
+        __m256d sum_vec = _mm256_fmadd_pd(a_vec, alpha_vec, beta_vec);
         _mm256_storeu_pd(result + i, sum_vec);
     }
 
     // The tail:
-    for (; i < n; ++i) result[i] = alpha * a[i];
+    for (; i < n; ++i) result[i] = alpha * a[i] + beta;
 }
 
 SIMSIMD_PUBLIC void simsimd_wsum_f64_haswell(                         //
@@ -427,8 +429,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_f64_haswell(                         //
         __m256d a_vec = _mm256_loadu_pd(a + i);
         __m256d b_vec = _mm256_loadu_pd(b + i);
         __m256d a_scaled_vec = _mm256_mul_pd(a_vec, alpha_vec);
-        __m256d b_scaled_vec = _mm256_mul_pd(b_vec, beta_vec);
-        __m256d sum_vec = _mm256_add_pd(a_scaled_vec, b_scaled_vec);
+        __m256d sum_vec = _mm256_fmadd_pd(b_vec, beta_vec, a_scaled_vec);
         _mm256_storeu_pd(result + i, sum_vec);
     }
 
@@ -461,8 +462,10 @@ SIMSIMD_PUBLIC void simsimd_sum_f16_haswell(simsimd_f16_t const *a, simsimd_f16_
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f16_haswell(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_f16_t *result) {
+                                              simsimd_distance_t beta, simsimd_f16_t *result) {
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
+    __m256 beta_vec = _mm256_set1_ps(beta_f32);
     __m256 alpha_vec = _mm256_set1_ps(alpha_f32);
 
     // The main loop:
@@ -470,7 +473,7 @@ SIMSIMD_PUBLIC void simsimd_scale_f16_haswell(simsimd_f16_t const *a, simsimd_si
     for (; i + 8 <= n; i += 8) {
         __m128i a_f16 = _mm_lddqu_si128((__m128i const *)(a + i));
         __m256 a_vec = _mm256_cvtph_ps(a_f16);
-        __m256 sum_vec = _mm256_mul_ps(a_vec, alpha_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(a_vec, alpha_vec, beta_vec);
         __m128i sum_f16 = _mm256_cvtps_ph(sum_vec, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
         _mm_storeu_si128((__m128i *)(result + i), sum_f16);
     }
@@ -478,7 +481,7 @@ SIMSIMD_PUBLIC void simsimd_scale_f16_haswell(simsimd_f16_t const *a, simsimd_si
     // The tail:
     for (; i < n; ++i) {
         simsimd_f32_t ai = SIMSIMD_F16_TO_F32(a + i);
-        simsimd_f32_t sum = alpha_f32 * ai;
+        simsimd_f32_t sum = alpha_f32 * ai + beta_f32;
         SIMSIMD_F32_TO_F16(sum, result + i);
     }
 }
@@ -516,8 +519,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_f16_haswell(                         //
         __m256 a_vec = _mm256_cvtph_ps(a_f16);
         __m256 b_vec = _mm256_cvtph_ps(b_f16);
         __m256 a_scaled_vec = _mm256_mul_ps(a_vec, alpha_vec);
-        __m256 b_scaled_vec = _mm256_mul_ps(b_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(a_scaled_vec, b_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(b_vec, beta_vec, a_scaled_vec);
         __m128i sum_f16 = _mm256_cvtps_ph(sum_vec, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
         _mm_storeu_si128((__m128i *)(result + i), sum_f16);
     }
@@ -555,16 +557,18 @@ SIMSIMD_PUBLIC void simsimd_sum_bf16_haswell(simsimd_bf16_t const *a, simsimd_bf
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_bf16_haswell(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                               simsimd_bf16_t *result) {
+                                               simsimd_distance_t beta, simsimd_bf16_t *result) {
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
     __m256 alpha_vec = _mm256_set1_ps(alpha_f32);
+    __m256 beta_vec = _mm256_set1_ps(beta_f32);
 
     // The main loop:
     simsimd_size_t i = 0;
     for (; i + 8 <= n; i += 8) {
         __m128i a_bf16 = _mm_lddqu_si128((__m128i const *)(a + i));
         __m256 a_vec = _simsimd_bf16x8_to_f32x8_haswell(a_bf16);
-        __m256 sum_vec = _mm256_mul_ps(a_vec, alpha_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(a_vec, alpha_vec, beta_vec);
         __m128i sum_bf16 = _simsimd_f32x8_to_bf16x8_haswell(sum_vec);
         _mm_storeu_si128((__m128i *)(result + i), sum_bf16);
     }
@@ -572,7 +576,7 @@ SIMSIMD_PUBLIC void simsimd_scale_bf16_haswell(simsimd_bf16_t const *a, simsimd_
     // The tail:
     for (; i < n; ++i) {
         simsimd_f32_t ai = SIMSIMD_BF16_TO_F32(a + i);
-        simsimd_f32_t sum = alpha_f32 * ai;
+        simsimd_f32_t sum = alpha_f32 * ai + beta_f32;
         SIMSIMD_F32_TO_BF16(sum, result + i);
     }
 }
@@ -610,8 +614,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_bf16_haswell(                          //
         __m256 a_vec = _simsimd_bf16x8_to_f32x8_haswell(a_bf16);
         __m256 b_vec = _simsimd_bf16x8_to_f32x8_haswell(b_bf16);
         __m256 a_scaled_vec = _mm256_mul_ps(a_vec, alpha_vec);
-        __m256 b_scaled_vec = _mm256_mul_ps(b_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(a_scaled_vec, b_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(b_vec, beta_vec, a_scaled_vec);
         __m128i sum_bf16 = _simsimd_f32x8_to_bf16x8_haswell(sum_vec);
         _mm_storeu_si128((__m128i *)(result + i), sum_bf16);
     }
@@ -641,8 +644,7 @@ SIMSIMD_PUBLIC void simsimd_fma_f32_haswell(                                //
         __m256 c_vec = _mm256_loadu_ps(c + i);
         __m256 ab_vec = _mm256_mul_ps(a_vec, b_vec);
         __m256 ab_scaled_vec = _mm256_mul_ps(ab_vec, alpha_vec);
-        __m256 c_scaled_vec = _mm256_mul_ps(c_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(ab_scaled_vec, c_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(c_vec, beta_vec, ab_scaled_vec);
         _mm256_storeu_ps(result + i, sum_vec);
     }
 
@@ -664,8 +666,7 @@ SIMSIMD_PUBLIC void simsimd_fma_f64_haswell(                                //
         __m256d c_vec = _mm256_loadu_pd(c + i);
         __m256d ab_vec = _mm256_mul_pd(a_vec, b_vec);
         __m256d ab_scaled_vec = _mm256_mul_pd(ab_vec, alpha_vec);
-        __m256d c_scaled_vec = _mm256_mul_pd(c_vec, beta_vec);
-        __m256d sum_vec = _mm256_add_pd(ab_scaled_vec, c_scaled_vec);
+        __m256d sum_vec = _mm256_fmadd_pd(c_vec, beta_vec, ab_scaled_vec);
         _mm256_storeu_pd(result + i, sum_vec);
     }
 
@@ -692,8 +693,7 @@ SIMSIMD_PUBLIC void simsimd_fma_f16_haswell(                                //
         __m256 c_vec = _mm256_cvtph_ps(c_f16);
         __m256 ab_vec = _mm256_mul_ps(a_vec, b_vec);
         __m256 ab_scaled_vec = _mm256_mul_ps(ab_vec, alpha_vec);
-        __m256 c_scaled_vec = _mm256_mul_ps(c_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(ab_scaled_vec, c_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(c_vec, beta_vec, ab_scaled_vec);
         __m128i sum_f16 = _mm256_cvtps_ph(sum_vec, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
         _mm_storeu_si128((__m128i *)(result + i), sum_f16);
     }
@@ -727,8 +727,7 @@ SIMSIMD_PUBLIC void simsimd_fma_bf16_haswell(                                  /
         __m256 c_vec = _simsimd_bf16x8_to_f32x8_haswell(c_bf16);
         __m256 ab_vec = _mm256_mul_ps(a_vec, b_vec);
         __m256 ab_scaled_vec = _mm256_mul_ps(ab_vec, alpha_vec);
-        __m256 c_scaled_vec = _mm256_mul_ps(c_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(ab_scaled_vec, c_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(c_vec, beta_vec, ab_scaled_vec);
         __m128i sum_bf16 = _simsimd_f32x8_to_bf16x8_haswell(sum_vec);
         _mm_storeu_si128((__m128i *)(result + i), sum_bf16);
     }
@@ -763,10 +762,12 @@ SIMSIMD_PUBLIC void simsimd_sum_i8_haswell(simsimd_i8_t const *a, simsimd_i8_t c
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_i8_haswell(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                             simsimd_i8_t *result) {
+                                             simsimd_distance_t beta, simsimd_i8_t *result) {
 
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
     __m256 alpha_vec = _mm256_set1_ps(alpha_f32);
+    __m256 beta_vec = _mm256_set1_ps(beta_f32);
     int sum_i32s[8], a_i32s[8];
 
     // The main loop:
@@ -780,7 +781,7 @@ SIMSIMD_PUBLIC void simsimd_scale_i8_haswell(simsimd_i8_t const *a, simsimd_size
         //! of relying on the slow `_mm256_cvtepi32_ps` instruction.
         __m256 a_vec = _mm256_cvtepi32_ps(_mm256_lddqu_si256((__m256i *)a_i32s));
         // The normal part.
-        __m256 sum_vec = _mm256_mul_ps(a_vec, alpha_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(a_vec, alpha_vec, beta_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(-128));
@@ -800,7 +801,7 @@ SIMSIMD_PUBLIC void simsimd_scale_i8_haswell(simsimd_i8_t const *a, simsimd_size
     // The tail:
     for (; i < n; ++i) {
         simsimd_f32_t ai = a[i];
-        simsimd_f32_t sum = alpha_f32 * ai;
+        simsimd_f32_t sum = alpha_f32 * ai + beta_f32;
         SIMSIMD_F32_TO_I8(sum, result + i);
     }
 }
@@ -846,8 +847,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_i8_haswell(                        //
         __m256 b_vec = _mm256_cvtepi32_ps(_mm256_lddqu_si256((__m256i *)b_i32s));
         // The normal part.
         __m256 a_scaled_vec = _mm256_mul_ps(a_vec, alpha_vec);
-        __m256 b_scaled_vec = _mm256_mul_ps(b_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(a_scaled_vec, b_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(b_vec, beta_vec, a_scaled_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(-128));
@@ -892,10 +892,12 @@ SIMSIMD_PUBLIC void simsimd_sum_u8_haswell(simsimd_u8_t const *a, simsimd_u8_t c
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_u8_haswell(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                             simsimd_u8_t *result) {
+                                             simsimd_distance_t beta, simsimd_u8_t *result) {
 
     simsimd_f32_t alpha_f32 = (simsimd_f32_t)alpha;
+    simsimd_f32_t beta_f32 = (simsimd_f32_t)beta;
     __m256 alpha_vec = _mm256_set1_ps(alpha_f32);
+    __m256 beta_vec = _mm256_set1_ps(beta_f32);
     int sum_i32s[8], a_i32s[8];
 
     // The main loop:
@@ -909,7 +911,7 @@ SIMSIMD_PUBLIC void simsimd_scale_u8_haswell(simsimd_u8_t const *a, simsimd_size
         //! of relying on the slow `_mm256_cvtepi32_ps` instruction.
         __m256 a_vec = _mm256_cvtepi32_ps(_mm256_lddqu_si256((__m256i *)a_i32s));
         // The normal part.
-        __m256 sum_vec = _mm256_mul_ps(a_vec, alpha_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(a_vec, alpha_vec, beta_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(0));
@@ -929,7 +931,7 @@ SIMSIMD_PUBLIC void simsimd_scale_u8_haswell(simsimd_u8_t const *a, simsimd_size
     // The tail:
     for (; i < n; ++i) {
         simsimd_f32_t ai = a[i];
-        simsimd_f32_t sum = alpha_f32 * ai;
+        simsimd_f32_t sum = alpha_f32 * ai + beta_f32;
         SIMSIMD_F32_TO_U8(sum, result + i);
     }
 }
@@ -975,8 +977,7 @@ SIMSIMD_PUBLIC void simsimd_wsum_u8_haswell(                        //
         __m256 b_vec = _mm256_cvtepi32_ps(_mm256_lddqu_si256((__m256i *)b_i32s));
         // The normal part.
         __m256 a_scaled_vec = _mm256_mul_ps(a_vec, alpha_vec);
-        __m256 b_scaled_vec = _mm256_mul_ps(b_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(a_scaled_vec, b_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(b_vec, beta_vec, a_scaled_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(0));
@@ -1030,8 +1031,7 @@ SIMSIMD_PUBLIC void simsimd_fma_i8_haswell(                                     
         // The normal part.
         __m256 ab_vec = _mm256_mul_ps(a_vec, b_vec);
         __m256 ab_scaled_vec = _mm256_mul_ps(ab_vec, alpha_vec);
-        __m256 c_scaled_vec = _mm256_mul_ps(c_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(ab_scaled_vec, c_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(c_vec, beta_vec, ab_scaled_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(-128));
@@ -1085,8 +1085,7 @@ SIMSIMD_PUBLIC void simsimd_fma_u8_haswell(                                     
         // The normal part.
         __m256 ab_vec = _mm256_mul_ps(a_vec, b_vec);
         __m256 ab_scaled_vec = _mm256_mul_ps(ab_vec, alpha_vec);
-        __m256 c_scaled_vec = _mm256_mul_ps(c_vec, beta_vec);
-        __m256 sum_vec = _mm256_add_ps(ab_scaled_vec, c_scaled_vec);
+        __m256 sum_vec = _mm256_fmadd_ps(c_vec, beta_vec, ab_scaled_vec);
         // Instead of serial calls to expensive `SIMSIMD_F32_TO_U8`, convert and clip with SIMD.
         __m256i sum_i32_vec = _mm256_cvtps_epi32(sum_vec);
         sum_i32_vec = _mm256_max_epi32(sum_i32_vec, _mm256_set1_epi32(0));
@@ -1143,8 +1142,9 @@ simsimd_sum_f64_skylake_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f64_skylake(simsimd_f64_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_f64_t *result) {
+                                              simsimd_distance_t beta, simsimd_f64_t *result) {
     __m512d alpha_vec = _mm512_set1_pd(alpha);
+    __m512d beta_vec = _mm512_set1_pd(beta);
     __m512d a_vec, b_vec, a_scaled_vec, sum_vec;
     __mmask8 mask = 0xFF;
 simsimd_scale_f64_skylake_cycle:
@@ -1157,7 +1157,7 @@ simsimd_scale_f64_skylake_cycle:
         a_vec = _mm512_loadu_pd(a);
         a += 8, n -= 8;
     }
-    sum_vec = _mm512_mul_pd(a_vec, alpha_vec);
+    sum_vec = _mm512_fmadd_pd(a_vec, alpha_vec, beta_vec);
     _mm512_mask_storeu_pd(result, mask, sum_vec);
     result += 8;
     if (n) goto simsimd_scale_f64_skylake_cycle;
@@ -1230,8 +1230,9 @@ simsimd_sum_f32_skylake_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f32_skylake(simsimd_f32_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_f32_t *result) {
+                                              simsimd_distance_t beta, simsimd_f32_t *result) {
     __m512 alpha_vec = _mm512_set1_ps(alpha);
+    __m512 beta_vec = _mm512_set1_ps(beta);
     __m512 a_vec, sum_vec;
     __mmask16 mask = 0xFFFF;
 
@@ -1245,7 +1246,7 @@ simsimd_scale_f32_skylake_cycle:
         a_vec = _mm512_loadu_ps(a);
         a += 16, n -= 16;
     }
-    sum_vec = _mm512_mul_ps(a_vec, alpha_vec);
+    sum_vec = _mm512_fmadd_ps(a_vec, alpha_vec, beta_vec);
     _mm512_mask_storeu_ps(result, mask, sum_vec);
     result += 16;
     if (n) goto simsimd_scale_f32_skylake_cycle;
@@ -1321,8 +1322,9 @@ simsimd_sum_bf16_skylake_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_bf16_skylake(simsimd_bf16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                               simsimd_bf16_t *result) {
+                                               simsimd_distance_t beta, simsimd_bf16_t *result) {
     __m512 alpha_vec = _mm512_set1_ps(alpha);
+    __m512 beta_vec = _mm512_set1_ps(beta);
     __m256i a_bf16_vec, b_bf16_vec, sum_bf16_vec;
     __m512 a_vec, b_vec, sum_vec;
     __mmask16 mask = 0xFFFF;
@@ -1337,7 +1339,7 @@ simsimd_wsum_bf16_skylake_cycle:
         a += 16, n -= 16;
     }
     a_vec = _simsimd_bf16x16_to_f32x16_skylake(a_bf16_vec);
-    sum_vec = _mm512_mul_ps(a_vec, alpha_vec);
+    sum_vec = _mm512_fmadd_ps(a_vec, alpha_vec, beta_vec);
     sum_bf16_vec = _simsimd_f32x16_to_bf16x16_skylake(sum_vec);
     _mm256_mask_storeu_epi16(result, mask, sum_bf16_vec);
     result += 16;
@@ -1398,7 +1400,6 @@ SIMSIMD_PUBLIC void simsimd_fma_f64_skylake(                                    
     __m512d beta_vec = _mm512_set1_pd(beta);
     __m512d a_vec, b_vec, c_vec, ab_vec, ab_scaled_vec, sum_vec;
     __mmask8 mask = 0xFF;
-
 simsimd_fma_f64_skylake_cycle:
     if (n < 8) {
         mask = (__mmask8)_bzhi_u32(0xFFFFFFFF, n);
@@ -1428,7 +1429,6 @@ SIMSIMD_PUBLIC void simsimd_fma_f32_skylake(                                    
     __m512 beta_vec = _mm512_set1_ps(beta);
     __m512 a_vec, b_vec, c_vec, ab_vec, ab_scaled_vec, sum_vec;
     __mmask16 mask = 0xFFFF;
-
 simsimd_fma_f32_skylake_cycle:
     if (n < 16) {
         mask = (__mmask16)_bzhi_u32(0xFFFFFFFF, n);
@@ -1459,7 +1459,6 @@ SIMSIMD_PUBLIC void simsimd_fma_bf16_skylake(                                   
     __m256i a_bf16_vec, b_bf16_vec, c_bf16_vec, sum_bf16_vec;
     __m512 a_vec, b_vec, c_vec, ab_vec, ab_scaled_vec, sum_vec;
     __mmask16 mask = 0xFFFF;
-
 simsimd_fma_bf16_skylake_cycle:
     if (n < 16) {
         mask = (__mmask16)_bzhi_u32(0xFFFFFFFF, n);
@@ -1520,10 +1519,10 @@ simsimd_sum_f16_sapphire_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_f16_sapphire(simsimd_f16_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                               simsimd_f16_t *result) {
-
+                                               simsimd_distance_t beta, simsimd_f16_t *result) {
     __mmask32 mask = 0xFFFFFFFF;
     __m512h alpha_vec = _mm512_set1_ph((_Float16)alpha);
+    __m512h beta_vec = _mm512_set1_ph((_Float16)beta);
     __m512h a_f16_vec, b_f16_vec;
     __m512h sum_f16_vec;
 simsimd_scale_f16_sapphire_cycle:
@@ -1536,7 +1535,7 @@ simsimd_scale_f16_sapphire_cycle:
         a_f16_vec = _mm512_loadu_ph(a);
         a += 32, n -= 32;
     }
-    sum_f16_vec = _mm512_mul_ph(a_f16_vec, alpha_vec);
+    sum_f16_vec = _mm512_fmadd_ph(a_f16_vec, alpha_vec, beta_vec);
     _mm512_mask_storeu_epi16(result, mask, _mm512_castph_si512(sum_f16_vec));
     result += 32;
     if (n) goto simsimd_scale_f16_sapphire_cycle;
@@ -1640,9 +1639,10 @@ simsimd_sum_u8_sapphire_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_u8_sapphire(simsimd_u8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_u8_t *result) {
+                                              simsimd_distance_t beta, simsimd_u8_t *result) {
     __mmask64 mask = 0xFFFFFFFFFFFFFFFFull;
     __m512h alpha_vec = _mm512_set1_ph((_Float16)alpha);
+    __m512h beta_vec = _mm512_set1_ph((_Float16)beta);
     __m512i a_u8_vec, b_u8_vec, sum_u8_vec;
     __m512h a_f16_low_vec, a_f16_high_vec;
     __m512h a_scaled_f16_low_vec, a_scaled_f16_high_vec, sum_f16_low_vec, sum_f16_high_vec;
@@ -1661,8 +1661,8 @@ simsimd_scale_u8_sapphire_cycle:
     a_f16_low_vec = _mm512_cvtepi16_ph(_mm512_unpacklo_epi8(a_u8_vec, _mm512_setzero_si512()));
     a_f16_high_vec = _mm512_cvtepi16_ph(_mm512_unpackhi_epi8(a_u8_vec, _mm512_setzero_si512()));
     // Scale:
-    sum_f16_low_vec = _mm512_mul_ph(a_f16_low_vec, alpha_vec);
-    sum_f16_high_vec = _mm512_mul_ph(a_f16_high_vec, alpha_vec);
+    sum_f16_low_vec = _mm512_fmadd_ph(a_f16_low_vec, alpha_vec, beta_vec);
+    sum_f16_high_vec = _mm512_fmadd_ph(a_f16_high_vec, alpha_vec, beta_vec);
     // Downcast:
     sum_i16_low_vec = _mm512_cvtph_epi16(sum_f16_low_vec);
     sum_i16_high_vec = _mm512_cvtph_epi16(sum_f16_high_vec);
@@ -1759,10 +1759,11 @@ simsimd_sum_i8_sapphire_cycle:
 }
 
 SIMSIMD_PUBLIC void simsimd_scale_i8_sapphire(simsimd_i8_t const *a, simsimd_size_t n, simsimd_distance_t alpha,
-                                              simsimd_i8_t *result) {
+                                              simsimd_distance_t beta, simsimd_i8_t *result) {
 
     __mmask64 mask = 0xFFFFFFFFFFFFFFFFull;
     __m512h alpha_vec = _mm512_set1_ph((_Float16)alpha);
+    __m512h beta_vec = _mm512_set1_ph((_Float16)beta);
     __m512i a_i8_vec, sum_i8_vec;
     __m512h a_f16_low_vec, a_f16_high_vec;
     __m512h sum_f16_low_vec, sum_f16_high_vec;
@@ -1781,8 +1782,8 @@ simsimd_wsum_i8_sapphire_cycle:
     a_f16_low_vec = _mm512_cvtepi16_ph(_mm512_cvtepi8_epi16(_mm512_castsi512_si256(a_i8_vec)));
     a_f16_high_vec = _mm512_cvtepi16_ph(_mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(a_i8_vec, 1)));
     // Scale:
-    sum_f16_low_vec = _mm512_mul_ph(a_f16_low_vec, alpha_vec);
-    sum_f16_high_vec = _mm512_mul_ph(a_f16_high_vec, alpha_vec);
+    sum_f16_low_vec = _mm512_fmadd_ph(a_f16_low_vec, alpha_vec, beta_vec);
+    sum_f16_high_vec = _mm512_fmadd_ph(a_f16_high_vec, alpha_vec, beta_vec);
     // Downcast:
     sum_i16_low_vec = _mm512_cvtph_epi16(sum_f16_low_vec);
     sum_i16_high_vec = _mm512_cvtph_epi16(sum_f16_high_vec);
@@ -1820,7 +1821,6 @@ SIMSIMD_PUBLIC void simsimd_wsum_i8_sapphire(                       //
     __m512h a_f16_low_vec, a_f16_high_vec, b_f16_low_vec, b_f16_high_vec;
     __m512h a_scaled_f16_low_vec, a_scaled_f16_high_vec, sum_f16_low_vec, sum_f16_high_vec;
     __m512i sum_i16_low_vec, sum_i16_high_vec;
-
 simsimd_wsum_i8_sapphire_cycle:
     if (n < 64) {
         mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFull, n);
@@ -1866,7 +1866,6 @@ SIMSIMD_PUBLIC void simsimd_fma_i8_sapphire(                                    
     __m512h c_f16_low_vec, c_f16_high_vec, ab_f16_low_vec, ab_f16_high_vec;
     __m512h ab_scaled_f16_low_vec, ab_scaled_f16_high_vec, sum_f16_low_vec, sum_f16_high_vec;
     __m512i sum_i16_low_vec, sum_i16_high_vec;
-
 simsimd_fma_i8_sapphire_cycle:
     if (n < 64) {
         mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFF, n);
@@ -1919,7 +1918,6 @@ SIMSIMD_PUBLIC void simsimd_fma_u8_sapphire(                                    
     __m512h c_f16_low_vec, c_f16_high_vec, ab_f16_low_vec, ab_f16_high_vec;
     __m512h ab_scaled_f16_low_vec, ab_scaled_f16_high_vec, sum_f16_low_vec, sum_f16_high_vec;
     __m512i sum_i16_low_vec, sum_i16_high_vec;
-
 simsimd_fma_u8_sapphire_cycle:
     if (n < 64) {
         mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFF, n);


### PR DESCRIPTION
New public APIs for C and Python:

1. `scale`: $\alpha * A_i + \beta$.
2. `sum`: $A_i + B_i$.

New compatibility interfaces for NumPy and OpenCV:

1. `add` for vector-vector and vector-scalar element-wise addition.
2. `multiply` for vector-vector and vector-scalar element-wise multiplication.
