### PR TITLE
feat: #184 Expose intersections rust

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -298,7 +298,7 @@ where
     fn vdot(a: &[Self], b: &[Self]) -> Option<ComplexProduct>;
 }
 
-/// `Sparse` provides trait methods for spare vectors.
+/// `Sparse` provides trait methods for sparse vectors.
 pub trait Sparse
 where
     Self: Sized,


### PR DESCRIPTION
Expose the `intersect` method, similar to numpy's `intersect1d` that gives the count of intersection between 2 integer vectors. 