### PR TITLE
WIP: Add benchmark for tfidf

### DIFF
--- a/scripts/bench_tfidf.rs
+++ b/scripts/bench_tfidf.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+
+const LINES_PER_DOCUMENT: usize = 1000;
+
+#[derive(Debug)]
+struct TfidfCalculator {
+    document_frequency: HashMap<String, usize>,
+    term_frequencies: Vec<HashMap<String, usize>>,
+    documents: Vec<String>,  // Store original documents
+    n_documents: usize,
+}
+
+impl TfidfCalculator {
+    fn new() -> Self {
+        TfidfCalculator {
+            document_frequency: HashMap::new(),
+            term_frequencies: Vec::new(),
+            documents: Vec::new(),
+            n_documents: 0,
+        }
+    }
+
+    fn tokenize(text: &str) -> Vec<String> {
+        text.split_whitespace()
+            .map(|word| word.to_lowercase()
+                .chars()
+                .filter(|c| c.is_alphanumeric())
+                .collect::<String>())
+            .filter(|word| !word.is_empty())
+            .collect()
+    }
+
+    fn process_document(&mut self, text: &str) {
+        let tokens = Self::tokenize(text);
+        let mut term_freq = HashMap::new();
+        let mut seen_terms = HashMap::new();
+
+        for token in tokens {
+            *term_freq.entry(token.clone()).or_insert(0) += 1;
+            seen_terms.insert(token, true);
+        }
+
+        for term in seen_terms.keys() {
+            *self.document_frequency.entry(term.clone()).or_insert(0) += 1;
+        }
+
+        self.term_frequencies.push(term_freq);
+        self.documents.push(text.to_string());
+        self.n_documents += 1;
+    }
+
+    fn calculate_tfidf(&self, term_freq: &HashMap<String, usize>) -> HashMap<String, f64> {
+        let mut tfidf = HashMap::new();
+        
+        for (term, freq) in term_freq {
+            if let Some(&df) = self.document_frequency.get(term) {
+                let tf = *freq as f64;
+                let idf = (self.n_documents as f64 / df as f64).ln();
+                tfidf.insert(term.clone(), tf * idf);
+            }
+        }
+        
+        tfidf
+    }
+
+    fn get_document_tfidf_vectors(&self) -> Vec<HashMap<String, f64>> {
+        self.term_frequencies
+            .iter()
+            .map(|tf| self.calculate_tfidf(tf))
+            .collect()
+    }
+
+    fn calculate_query_tfidf(&self, query: &str) -> HashMap<String, f64> {
+        let tokens = Self::tokenize(query);
+        let mut term_freq = HashMap::new();
+        
+        for token in tokens {
+            *term_freq.entry(token).or_insert(0) += 1;
+        }
+        
+        self.calculate_tfidf(&term_freq)
+    }
+
+    fn cosine_similarity(v1: &HashMap<String, f64>, v2: &HashMap<String, f64>) -> f64 {
+        let mut dot_product = 0.0;
+        let mut norm1 = 0.0;
+        let mut norm2 = 0.0;
+
+        // Calculate dot product and norms
+        for (term, score1) in v1 {
+            norm1 += score1 * score1;
+            if let Some(score2) = v2.get(term) {
+                dot_product += score1 * score2;
+            }
+        }
+
+        for (_term, score2) in v2 {
+            norm2 += score2 * score2;
+        }
+
+        // Return cosine similarity
+        if norm1 == 0.0 || norm2 == 0.0 {
+            0.0
+        } else {
+            dot_product / (norm1.sqrt() * norm2.sqrt())
+        }
+    }
+
+    fn find_matching_documents(&self, query: &str, top_n: usize) -> Vec<(usize, f64)> {
+        let query_tfidf = self.calculate_query_tfidf(query);
+        let doc_tfidfs = self.get_document_tfidf_vectors();
+        
+        let mut similarities: Vec<(usize, f64)> = doc_tfidfs
+            .iter()
+            .enumerate()
+            .map(|(idx, doc_tfidf)| {
+                (idx, Self::cosine_similarity(&query_tfidf, doc_tfidf))
+            })
+            .collect();
+        
+        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        
+        // Return top N results
+        similarities.into_iter().take(top_n).collect()
+    }
+}
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <filename>", args[0]);
+        std::process::exit(1);
+    }
+
+    let path = Path::new(&args[1]);
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut calculator = TfidfCalculator::new();
+
+    // Process the file in chunks of LINES_PER_DOCUMENT lines
+    let mut current_document = String::new();
+    let mut line_count = 0;
+
+    for line in reader.lines() {
+        let line = line?;
+        current_document.push_str(&line);
+        current_document.push('\n');
+        line_count += 1;
+
+        if line_count == LINES_PER_DOCUMENT {
+            calculator.process_document(&current_document);
+            current_document.clear();
+            line_count = 0;
+        }
+    }
+
+    if !current_document.is_empty() {
+        calculator.process_document(&current_document);
+    }
+}


### PR DESCRIPTION
Add a vanilla Rust program for calculating tfidf scores and calculating the top 10 similar documents

We use a cosine similarity for calculating relevancy of documents for a given query.

@ashvardanian , thanks for your time ! 
Wanted to check with you on the approach to see if it makes sense to you as a valid benchmark 

Use the `leipzig1m` and the § XL Sum dataset` as corpuses. 
I assumes that each 10000 lines in the `leipzig1m` dataset is a single document and then calculate the tf-idf scores for each (term, document) in the corpus. 

2. Given a query, calculate the tf-idf score of a given query based on the same corpus (and assume the query to be a separate document)

3. The next step is to calculate the cosine score. I couldn't fine a good source for where I can calculate the score as a vector for a query or a document (Claude gave me a fn that I could possibly use) 

4. Once we have a cosine similarity score, sort and fetch top 10. 

For benchmarking SImSIMD, I assume the cosine part is where I can use methods from SimSIMD and benchmark it against the vanilla implementation ? 
And for the query, in [memchr vs stringzilla](https://github.com/ashvardanian/memchr_vs_stringzilla/blob/main/src/lib.rs#L9) you basically pick a random set of tokens and then benchmark searching from left and right using memchr and stringzilla . I was thinking of doing something similar by picking terms at random from the corpus and constructing random queries to benchmark. 
