### PR TITLE
Fixed 2 typos in README relating to Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ const distance = hamming(binaryVectorA, binaryVectorB);
 
 ## Using SimSIMD in Swift
 
-To install, simply add the following dependency to you `Package.swift`:
+To install, simply add the following dependency to your `Package.swift`:
 
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ const binaryVectorB = toBinary(vectorB);
 const distance = hamming(binaryVectorA, binaryVectorB);
 ```
 
-## Using SimSIMD in Sift
+## Using SimSIMD in Swift
 
 To install, simply add the following dependency to you `Package.swift`:
 


### PR DESCRIPTION
As title describes, this commit fixes two typos in the README relating to using this library using Swift. More specifically it changes the `Sift` to `Swift` in the related header so it be can be correctly jumped to when clicking the header link, and changes `you Package.swift` to `your Package.swift`.

## Header link
Broken Swift link in:

> has [Python](https://github.com/ashvardanian/SimSIMD?tab=readme-ov-file#using-simsimd-in-python), [Rust](https://github.com/ashvardanian/SimSIMD?tab=readme-ov-file#using-simsimd-in-rust), [JS](https://github.com/ashvardanian/SimSIMD?tab=readme-ov-file#using-simsimd-in-javascript), and [Swift](https://github.com/ashvardanian/SimSIMD?tab=readme-ov-file#using-simsimd-in-swift) bindings.

Problem:

> ## Using SimSIMD in Sift

Fix:

> ## Using SimSIMD in Swift


## you Package.swift
`you Package.swift` typo

> To install, simply add the following dependency to you Package.swift:

Fix:

> To install, simply add the following dependency to your Package.swift:
