### PR TITLE
Fix: Wrong variable used in `l2sq_bf16_sve`

### DIFF
--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -970,7 +970,7 @@ SIMSIMD_PUBLIC void simsimd_l2sq_bf16_sve(simsimd_bf16_t const *a_enum, simsimd_
         svfloat32_t a_minus_b_low_vec = svsub_f32_x(pg_low_vec, a_low_vec, b_low_vec);
         svfloat32_t a_minus_b_high_vec = svsub_f32_x(pg_high_vec, a_high_vec, b_high_vec);
         d2_low_vec = svmla_f32_x(pg_vec, d2_low_vec, a_minus_b_low_vec, a_minus_b_low_vec);
-        d2_high_vec = svmla_f32_x(pg_vec, d2_high_vec, a_minus_b_low_vec, a_minus_b_low_vec);
+        d2_high_vec = svmla_f32_x(pg_vec, d2_high_vec, a_minus_b_high_vec, a_minus_b_high_vec);
         i += svcnth();
     } while (i < n);
     simsimd_f32_t d2 = svaddv_f32(svptrue_b32(), d2_low_vec) + svaddv_f32(svptrue_b32(), d2_high_vec);


### PR DESCRIPTION
I am working on benchmarking USearch on different microarchitectures in cloud instances for a research project. 
I noticed a drop in recall in Graviton 4 in all of my datasets when using the `l2sq` metric with `bf16`. Here is an example of the recalls I'm getting with one of my datasets:

|                 Microarchitecture |    Recall |          QPS|
|----------------------------------:|----------:|-------------:|
|                AMD ZEN 4 (r7a.2x) |     >0.99 |     6.54 |
|       **AWS GRAVITON 4 (r8g.2x)** | **0.71** | **3.85** |
|                AMD ZEN 3 (r6a.2x) |     >0.99 |     3.20 |
| INTEL SAPPHIRE RAPIDS Z (r7iz.2x) |     >0.99 |     2.70 |
|    INTEL SAPPHIRE RAPIDS (r7i.2x) |     >0.99 |     2.50 |

I found a small bug (probably a typo) in the code of `l2sq_bf16_sve`. This PR should fix the issue. 


(p.s. Thx for this amazing project)
