### PR TITLE
Improve instruction scheduling for Jaccard distance Icelake

### DIFF
--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -435,6 +435,13 @@ SIMSIMD_PUBLIC void simsimd_intersect_u16_ice(        //
         }
         b_min = b_vec.u16[0];
 
+        __m512i a_last_broadcasted = _mm512_set1_epi16(*(short const *)&a_max);
+        __m512i b_last_broadcasted = _mm512_set1_epi16(*(short const *)&b_max);
+        __mmask32 a_step_mask = _mm512_cmple_epu16_mask(a_vec.zmm, b_last_broadcasted);
+        __mmask32 b_step_mask = _mm512_cmple_epu16_mask(b_vec.zmm, a_last_broadcasted);
+        a += 32 - _lzcnt_u32((simsimd_u32_t)a_step_mask);
+        b += 32 - _lzcnt_u32((simsimd_u32_t)b_step_mask);
+
         // Now we are likely to have some overlap, so we can intersect the registers
         __mmask32 a_matches = _simsimd_intersect_u16x32_ice(a_vec.zmm, b_vec.zmm);
 
@@ -442,13 +449,6 @@ SIMSIMD_PUBLIC void simsimd_intersect_u16_ice(        //
         // but we don't need it here:
         //      _mm512_mask_compressstoreu_epi16(c, a_matches, a_vec);
         c += _mm_popcnt_u32(a_matches); // MSVC has no `_popcnt32`
-
-        __m512i a_last_broadcasted = _mm512_set1_epi16(*(short const *)&a_max);
-        __m512i b_last_broadcasted = _mm512_set1_epi16(*(short const *)&b_max);
-        __mmask32 a_step_mask = _mm512_cmple_epu16_mask(a_vec.zmm, b_last_broadcasted);
-        __mmask32 b_step_mask = _mm512_cmple_epu16_mask(b_vec.zmm, a_last_broadcasted);
-        a += 32 - _lzcnt_u32((simsimd_u32_t)a_step_mask);
-        b += 32 - _lzcnt_u32((simsimd_u32_t)b_step_mask);
     }
 
     simsimd_intersect_u16_serial(a, b, a_end - a, b_end - b, results);
@@ -500,6 +500,13 @@ SIMSIMD_PUBLIC void simsimd_intersect_u32_ice(        //
         }
         b_min = b_vec.u32[0];
 
+        __m512i a_last_broadcasted = _mm512_set1_epi32(*(int const *)&a_max);
+        __m512i b_last_broadcasted = _mm512_set1_epi32(*(int const *)&b_max);
+        __mmask16 a_step_mask = _mm512_cmple_epu32_mask(a_vec.zmm, b_last_broadcasted);
+        __mmask16 b_step_mask = _mm512_cmple_epu32_mask(b_vec.zmm, a_last_broadcasted);
+        a += 32 - _lzcnt_u32((simsimd_u32_t)a_step_mask);
+        b += 32 - _lzcnt_u32((simsimd_u32_t)b_step_mask);
+
         // Now we are likely to have some overlap, so we can intersect the registers
         __mmask16 a_matches = _simsimd_intersect_u32x16_ice(a_vec.zmm, b_vec.zmm);
 
@@ -507,13 +514,6 @@ SIMSIMD_PUBLIC void simsimd_intersect_u32_ice(        //
         // but we don't need it here:
         //      _mm512_mask_compressstoreu_epi32(c, a_matches, a_vec);
         c += _mm_popcnt_u32(a_matches); // MSVC has no `_popcnt32`
-
-        __m512i a_last_broadcasted = _mm512_set1_epi32(*(int const *)&a_max);
-        __m512i b_last_broadcasted = _mm512_set1_epi32(*(int const *)&b_max);
-        __mmask16 a_step_mask = _mm512_cmple_epu32_mask(a_vec.zmm, b_last_broadcasted);
-        __mmask16 b_step_mask = _mm512_cmple_epu32_mask(b_vec.zmm, a_last_broadcasted);
-        a += 32 - _lzcnt_u32((simsimd_u32_t)a_step_mask);
-        b += 32 - _lzcnt_u32((simsimd_u32_t)b_step_mask);
     }
 
     simsimd_intersect_u32_serial(a, b, a_end - a, b_end - b, results);


### PR DESCRIPTION
The sequence for calculating the start of the next iteration has a high latency, so moving it to earlier in the loop improves IPC and thus throughput.

Results from my Zen 4 (~10% better IPC and throughput across the board):
<details><summary>Old</summary>

```
2025-02-14T17:47:24-05:00
Running build_release/simsimd_bench
Run on (16 X 5573 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 32768 KiB (x1)
Load Average: 0.74, 0.39, 0.20
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------------------------------------
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=1>/min_time:10.000/threads:1           84.4 ns         84.4 ns    164129641 bytes=12.1321G/s error=0 matches=1 pairs=11.8478M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=6>/min_time:10.000/threads:1           84.7 ns         84.7 ns    164508862 bytes=12.0921G/s error=0 matches=6 pairs=11.8087M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=64>/min_time:10.000/threads:1          81.3 ns         81.3 ns    171422449 bytes=12.5983G/s error=0 matches=64 pairs=12.3031M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=121>/min_time:10.000/threads:1         62.0 ns         62.0 ns    226625294 bytes=16.5166G/s error=0 matches=121 pairs=16.1295M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=1>/min_time:10.000/threads:1           513 ns          513 ns     27066276 bytes=8.97969G/s error=0 matches=1 pairs=1.94872M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=6>/min_time:10.000/threads:1           512 ns          512 ns     27546339 bytes=9.00401G/s error=0 matches=6 pairs=1.95399M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=64>/min_time:10.000/threads:1          522 ns          522 ns     26990419 bytes=8.83059G/s error=0 matches=64 pairs=1.91636M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=121>/min_time:10.000/threads:1         523 ns          523 ns     26433917 bytes=8.81232G/s error=0 matches=121 pairs=1.9124M/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=1>/min_time:10.000/threads:1          1297 ns         1297 ns     11104872 bytes=25.6576G/s error=0 matches=1 pairs=770.963k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=6>/min_time:10.000/threads:1          1352 ns         1352 ns     11054915 bytes=24.6195G/s error=0 matches=6 pairs=739.77k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=64>/min_time:10.000/threads:1         1351 ns         1351 ns     10133858 bytes=24.6299G/s error=0 matches=64 pairs=740.082k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=121>/min_time:10.000/threads:1        1288 ns         1288 ns     10139932 bytes=25.8479G/s error=0 matches=121 pairs=776.678k/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=10>/min_time:10.000/threads:1         556 ns          556 ns     25116119 bytes=14.7348G/s error=0 matches=10 pairs=1.79868M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=51>/min_time:10.000/threads:1         553 ns          553 ns     25212883 bytes=14.8117G/s error=0 matches=51 pairs=1.80807M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=512>/min_time:10.000/threads:1        531 ns          531 ns     26194429 bytes=15.4215G/s error=0 matches=512 pairs=1.88251M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=972>/min_time:10.000/threads:1        506 ns          506 ns     27828417 bytes=16.1947G/s error=0 matches=972 pairs=1.97689M/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=10>/min_time:10.000/threads:1        3146 ns         3146 ns      4414396 bytes=11.7184G/s error=0 matches=10 pairs=317.883k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=51>/min_time:10.000/threads:1        3161 ns         3161 ns      4417758 bytes=11.6636G/s error=0 matches=51 pairs=316.396k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=512>/min_time:10.000/threads:1       3207 ns         3207 ns      4355391 bytes=11.495G/s error=0 matches=512 pairs=311.822k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=972>/min_time:10.000/threads:1       3275 ns         3275 ns      4291285 bytes=11.2559G/s error=0 matches=972 pairs=305.336k/s

 Performance counter stats for 'build_release/simsimd_bench --benchmark_filter=intersect_u32.*ice':

        388,387.84 msec task-clock:u                     #    1.002 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           149,179      page-faults:u                    #  384.098 /sec                      
 2,118,306,231,190      cycles:u                         #    5.454 GHz                         (38.46%)
    14,854,679,183      stalled-cycles-frontend:u        #    0.70% frontend cycles idle        (38.45%)
 4,181,545,946,294      instructions:u                   #    1.97  insn per cycle            
                                                  #    0.00  stalled cycles per insn     (38.45%)
   377,203,028,903      branches:u                       #  971.202 M/sec                       (38.47%)
     1,229,851,419      branch-misses:u                  #    0.33% of all branches             (38.47%)
   530,661,647,099      L1-dcache-loads:u                #    1.366 G/sec                       (38.47%)
    92,537,220,791      L1-dcache-load-misses:u          #   17.44% of all L1-dcache accesses   (38.47%)
   <not supported>      LLC-loads:u                                                           
   <not supported>      LLC-load-misses:u                                                     
     1,544,766,926      L1-icache-loads:u                #    3.977 M/sec                       (38.47%)
         6,612,797      L1-icache-load-misses:u          #    0.43% of all L1-icache accesses   (38.47%)
     1,460,328,272      dTLB-loads:u                     #    3.760 M/sec                       (38.47%)
         3,127,481      dTLB-load-misses:u               #    0.21% of all dTLB cache accesses  (38.47%)
             8,538      iTLB-loads:u                     #   21.983 /sec                        (38.46%)
         1,331,520      iTLB-load-misses:u               # 15595.22% of all iTLB cache accesses  (38.46%)

     387.511520812 seconds time elapsed

     387.402869000 seconds user
       0.983999000 seconds sys
```
</details>

<details><summary>New</summary>

```
2025-02-14T17:56:27-05:00
Running build_release/simsimd_bench
Run on (16 X 5573 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 32768 KiB (x1)
Load Average: 0.28, 0.55, 0.43
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------------------------------------
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=1>/min_time:10.000/threads:1           76.5 ns         76.5 ns    187526215 bytes=13.3868G/s error=0 matches=1 pairs=13.073M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=6>/min_time:10.000/threads:1           75.3 ns         75.3 ns    183575798 bytes=13.5928G/s error=0 matches=6 pairs=13.2742M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=64>/min_time:10.000/threads:1          72.9 ns         72.9 ns    195075396 bytes=14.0505G/s error=0 matches=64 pairs=13.7212M/s
intersect_u32_ice<|A|=128,|B|=128,|A∩B|=121>/min_time:10.000/threads:1         52.5 ns         52.5 ns    269233339 bytes=19.497G/s error=0 matches=121 pairs=19.04M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=1>/min_time:10.000/threads:1           460 ns          460 ns     30852775 bytes=10.013G/s error=0 matches=1 pairs=2.17297M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=6>/min_time:10.000/threads:1           464 ns          464 ns     30365003 bytes=9.93316G/s error=0 matches=6 pairs=2.15563M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=64>/min_time:10.000/threads:1          477 ns          477 ns     29622052 bytes=9.66011G/s error=0 matches=64 pairs=2.09638M/s
intersect_u32_ice<|A|=128,|B|=1024,|A∩B|=121>/min_time:10.000/threads:1         483 ns          483 ns     28816735 bytes=9.54467G/s error=0 matches=121 pairs=2.07132M/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=1>/min_time:10.000/threads:1          1296 ns         1296 ns     11659689 bytes=25.6846G/s error=0 matches=1 pairs=771.771k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=6>/min_time:10.000/threads:1          1185 ns         1185 ns     11630410 bytes=28.08G/s error=0 matches=6 pairs=843.749k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=64>/min_time:10.000/threads:1         1233 ns         1233 ns     12037020 bytes=26.9813G/s error=0 matches=64 pairs=810.736k/s
intersect_u32_ice<|A|=128,|B|=8192,|A∩B|=121>/min_time:10.000/threads:1        1301 ns         1300 ns     11135362 bytes=25.5903G/s error=0 matches=121 pairs=768.939k/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=10>/min_time:10.000/threads:1         469 ns          469 ns     29854209 bytes=17.4741G/s error=0 matches=10 pairs=2.13306M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=51>/min_time:10.000/threads:1         467 ns          467 ns     29841733 bytes=17.5312G/s error=0 matches=51 pairs=2.14004M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=512>/min_time:10.000/threads:1        453 ns          453 ns     30741252 bytes=18.0689G/s error=0 matches=512 pairs=2.20568M/s
intersect_u32_ice<|A|=1024,|B|=1024,|A∩B|=972>/min_time:10.000/threads:1        423 ns          423 ns     32907944 bytes=19.3455G/s error=0 matches=972 pairs=2.36151M/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=10>/min_time:10.000/threads:1        2649 ns         2649 ns      5285592 bytes=13.9146G/s error=0 matches=10 pairs=377.458k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=51>/min_time:10.000/threads:1        2649 ns         2649 ns      5281503 bytes=13.9166G/s error=0 matches=51 pairs=377.512k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=512>/min_time:10.000/threads:1       2695 ns         2695 ns      5204297 bytes=13.6771G/s error=0 matches=512 pairs=371.015k/s
intersect_u32_ice<|A|=1024,|B|=8192,|A∩B|=972>/min_time:10.000/threads:1       2742 ns         2742 ns      5127118 bytes=13.4452G/s error=0 matches=972 pairs=364.725k/s

 Performance counter stats for 'build_release/simsimd_bench --benchmark_filter=intersect_u32.*ice':

        378,773.25 msec task-clock:u                     #    1.002 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           148,600      page-faults:u                    #  392.319 /sec                      
 2,066,593,126,358      cycles:u                         #    5.456 GHz                         (38.46%)
    16,214,559,635      stalled-cycles-frontend:u        #    0.78% frontend cycles idle        (38.45%)
 4,638,501,318,817      instructions:u                   #    2.24  insn per cycle            
                                                  #    0.00  stalled cycles per insn     (38.46%)
   415,750,172,798      branches:u                       #    1.098 G/sec                       (38.47%)
     1,409,265,028      branch-misses:u                  #    0.34% of all branches             (38.47%)
   587,137,002,903      L1-dcache-loads:u                #    1.550 G/sec                       (38.47%)
   102,155,875,266      L1-dcache-load-misses:u          #   17.40% of all L1-dcache accesses   (38.47%)
   <not supported>      LLC-loads:u                                                           
   <not supported>      LLC-load-misses:u                                                     
     1,914,559,090      L1-icache-loads:u                #    5.055 M/sec                       (38.47%)
        10,470,252      L1-icache-load-misses:u          #    0.55% of all L1-icache accesses   (38.47%)
     1,615,089,974      dTLB-loads:u                     #    4.264 M/sec                       (38.47%)
         3,088,936      dTLB-load-misses:u               #    0.19% of all dTLB cache accesses  (38.47%)
             6,858      iTLB-loads:u                     #   18.106 /sec                        (38.46%)
         1,153,106      iTLB-load-misses:u               # 16814.03% of all iTLB cache accesses  (38.46%)

     377.888217448 seconds time elapsed

     377.795600000 seconds user
       0.975983000 seconds sys
```
</details>

[Godbolt repro](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIMwAcpK4AMngMmAByPgBGmMQSZhqkAA6oCoRODB7evv5BaRmOAmER0SxxCVxJtpj2xQxCBEzEBDk%2BfoG19VlNLQSlUbHxickKza3teV3j/YPllaMAlLaoXsTI7BzmAMzhyN5YANQmO254LCzhBMThAHQIp9gmGgCCL68EAJ4pmFhURy8DAywAi6COyAQLSOGRYsPQAH0YgEEQRTlY3t9fv9AcC8KC/hCocQYRd4Qi8JJVGZUeiPh8sX9MACQWCidDYeS8Ci0TsMZ8fkyAUDWYTIRyyRdEV4eXTMYKcaLwQoECQCKS4VKKVwAGy0vkMhXM3FKmGq1oa8leXX6/mMxX4tnXS1avA7Gm8u1G4V4gng52crVed22w3Y42m2gCYBHKNGF0sRF4HWSUPy8M%2ByPR2PZwOJhFeFNp97poVHKhRpjqvOIqghz1hsvoNYxegJ2tFhtvRsOzX5wup6uS/MZABemGL9ojw47g/bCPwswYm2L9LMO3%2B4UwRyEAEkALJ7/cAEQRyjkFhCu7cR3CtC3MOajlM3fXm4iO4PR9Pu8iABVsAAJUiV4QlvBh7w/WZn3pN4j2/BFfwA4DQPnYMPTQkNiE8CAawLesjlUUhwPVBglhOAB2CwjmITACHWBgjggVQTjOU4bzIyib2Y1jnh2bAmPdI4AFojjIpZ0Uo48Pngg8f3/ICQLAvDrT1Ic%2B2lG1sNoXCZwLG11SIkixPIkwqJouiGKYlj2PYkyuOs3iniY3URJMiS%2BSkmSvzkxCFJQ5S9JlVE0JRbTdI0gseUI4jnU4szqNo%2BjiEYnjbLOeyzO4mz%2BOciAAjc8TJLM6S4J8k8/OQpTMIwlSsJICKrQIoy4tM8ykqstLcv4zKKOy1i3DsiAhNEorPJK7zD18pDFNQlSDLQrSGvmtSYuM%2BL2sslLHKeZyNv69LuNc0alg86iJrKqaKpmgLQpClSwuWoLopawResSrbUpyviBP2na2Iy/LCtO4qKNKksIdkirz0va8jgAN1QPBlT0654iUBx8JpJRbjECAjgJgmAHoiY%2BQmapCtBgXVAAqJhiLqjCqfGI4aZiYjidJt5ybwscJ3VJgEXoIwCAQBm9L5kKYiFxhgFF4iSbJwm8MXZpl351naIULxaAIBQztg951xSYgmGAFgmCOABxNwbxSLwVQRVAUgaBQ1x2E2zYt63baOCZgDoiBzDMJh4epYPiOD0PVAAVmqKgI5OMwQ7DuOzHh2hE%2BDmIrjMLPk9oUdkEEfOzDSFJi7RZPI%2BT6O05iAB3Uu6%2BqeGc7wPPk4k18PdN83LYOQwYyrG48BiLwCG3e2VQgBEERH25x8nueoH9wOo7DsxSBbswqG31PW9oUh263wvK9SZ3z53xv99j1uT%2BD06VhOGPBu58mP8/r/P6YFIUloL4qJUCsWPOWIEDgsjd0huVeSVU5pBQWgiPCaNiAYwIFjVQNo8CbFngiFgac8BHHpkcOe%2BDqiEJiG1fk5NSEEKIVwEBJDLhp3nveUExAESYBSG6MwEBiHEMkAbd%2BBNaHkKODEBhpxQF4LIdjBAXgqAVgnFwnhEB2YkP3PuM8QEtGvGPG4CwQjXg0JkUwBQABrVyDAWAaA0IwmRLDkAsBSBEAAjpw7hIYLYWL4cRShcoIYmNkYQpgZh7HMOqKwx0HCVHul8UQ4iAQjFBLoUwHY4TZFRPYR41R/DiLVGSYTUh3jLE6jEjYyROxpERJpE4lxmB3GxJpCUvhXA/GFJEaYixVibFhKkUwzJdS3E5K8WY8xfCt7iKMUrTplwxk9I0Ok/pDjIlDIaSM5pYy%2BE7HaQEoJJSelcDscsmpeCxkIjWY0zxmyfHWNscRYhEiOkkK6aU8pXBKnVMySUi5zjhlNLObcipDy2niK4NM4RLzgniL6VUgZLCVQKKURstRxEESaO0YBLRFg9FuGecU%2BZZTrHVAySwn5lyNmAvGXcyZoS/Hgr2UU15hyllwpWTc8xvz6lXJ4VSiAdydlEMFU8xlsyDlEpYEkUlkTyV/PWQClpxLkgJJhRC4xTLoUxFZV8hF8jFH0BReo9FWjlA6IRAYvR%2BLmUSrMJ8%2BFMrzkUoVVs4loKmCgpiGYK1czuk2thTqh1FiuX/OuXy4ltLJmeu9eK8p65pUcuDfK0NiqWBcEFWkvxXqAkzKhTGu58aqWJp5aMoFNQVVaujYS95BbZXcspSm21IK/E7Erb62NNbHVyuLRy/lkqI3NtbW86x2r7UJqdcml1kr03CpbdmyFHVtoAD9GpBgMksXtxyzBlJWgicKxLiKCKTtuhBeo92SsSaZLdi1T0NWHQekGBpuxg0NiTT8V1TwwyvG/YxiNkbzhQWgrGFIcHf0VpCxmlMBAszpuLSK6FIPU1ZuozmObeZ4HHCFQWws5Zi3nJLdU0tsPyyOGB9VBMVZ4CXCuWmWsdZ6yoYbcmr6/wIG3DEMxdQHwXH/pgNgggqxZHLCQBG8QvgwgtrQWgRDiCmy%2BAoJiYTaLAEo5PVBRxhP0AUPrCEhhxHblcV4Qg25YQ8ZADmvAAI%2BEyxFggAaRwhLmB1I58R1mcN2fdAxyFPNUaCHRpgTG8GcZ4Dxo8h5rniOEdlsR2jut9aio/guhg8WLqBOVkFAizNaaZaIZwhg4J%2BmW2sDlojjxH1kYpuqbLNNsvS1cIwmISdqKRZs/FtDGHKuMI0PFoEgn4b%2BZCglHNKSxGjkuPF7zcGCLoRMDHCwuoZvSTK9/B6IUZQzYsCmBbyWwY5b68gPxCI9tzvKw3BAdBtx8Ma0cVydlBZ1cc85hrRWbsZVq3lzz5XyaCz23cUbLAC2VnQF4JBeA05QFEWYQhVWlhMGeeTaWP2/sA9QEwIHIOwe4OhdD/xZWhuE1fbuXzqD/OOHjEplT6MjgN0ILZkwOoNAg8igBknGCsGbDp3Y8IiNaB9fk5bKM6pUAsj1RWcIwA8ecyIXliEqBnEtEo1BhmwCG7bgboYdURAiG/v9OqCzftWMwnvJseTzYGBgA4ILvrxADApCIQLSTdw7gS4qzlq4SWltfwgwLM5OVQHff83cabs2uAxy2x7z%2BXuXNu/q4dgPQeLBdZjot6hnv0sYWlhbX3Lmfvx5D2H/kzuCcAlFsZo3mATcCHN5b%2BINuHnoHhoYTY%2Bvty/xNs7XGk8jhpBQc70752mKC0z3ZjP4Qj3OcK5YezsKbx3fe5RFP38CYT6sHC%2Bb4fF/%2B%2BQL9y4yPUfA4yBjiHUOoO0xh3Dr%2Bg%2BmBZ834H906289J/G4TFL39B%2Bj4K7Hrf8fE/J972dtsaiPudmb%2BjED2V6T2k%2BDmr2uW6AH2i%2BhMEBK%2BoCa%2BC%2Bi%2BCOAeSOJymSgO%2B%2BoO1Q4OeCdC2O5%2Bn8GeV%2BMeOed%2Bweoej%2B6%2B5ML%2BX8I%2BoBcK6BX%2BVBCe%2BejGX8uw7424kQ2AAA6giEIG4AABLYCgJdZebP7rh678FCEiHiHgzfxH7FZmLoIxDYSo6iDjCEhYEIp0RcAoo0wQDOjQ6OaX6qAkFQp0KEbqFIhaHoA6GTz5ZsqnJKAEBGFNIQAmFmEn6swSRbpkFWFP5ipVqCy6EpBUoFp1IGpcLwYtI35/YHYGDjAOEo5OHqF/DWEEptrSyRHRH6GrLOJxH2wlrjKsHb4sBhapEaGOHOHZGhFEKNb9IjQkJnyCBYxQBe4w5IKTxRElLWGIGtFhKiRCxFydHoTdFp6ohLD5H9FUrWG7CuAWZcGfyvqRCoANxU4t60Sxh4DmJ1Biaa5Qh9Ywiy7bioBW617nE7E6aMTM4ODN4WTKa6GoLO65FvKX4ECQjl72LIJE6AboSYJ6jYKYBWaI6XAHaQksBqqgZExHAsZTy/zxBEK0AKDAJUzNBbjgiWxW5iYMBgld7YSbBA57H8AkiYCqBpCtBi7PEWw/GsYKCkCF4IlLx3Gm5V5iSYCEiEBHCsa0RmbSGS4fzsqFpoDOJaxaZEC0TA7eH7au5Vi/HMm7b%2BbWHIAtFuEsAIjlyVxdHfHKlnQkYImHgABqN4UI8mDAwCHOOpl8ggd%2B9OaxH8uweuYAYA8hwhYhEhHxhBYiWG9hmhGRDRrhAa2Mhhxhphb05hW6lhORfpkOLmtR6R2hWRoZo6SCEZ3hvh0Z/hNMgROowR8ZPqXxfRXChRWpjiJRyiZRPaSRUJSZgZ9RaZxZMa8x5ZJSMR1ZHiCRWylRyRahaRQZqZuhsBTRy%2BIxbk4xepUxK6/Y9YvRBRgxTRwxcKbR05kxcSc50oC57ZAxYySx64KxCckKKWqGPmqmQJIYQWIWfiYWdWokjyMBbk6iMW9G8WNMb58m1g/SpguOz63YPcns/cEIBg8YC8Y8E8U8zs7swF3sNsdszsTsLsWQCgHAKwtAnAMcvAfgHAWgpAqAnAg0lgRWGJ6wTeuwPApABAmg6FKw5iIAOwOwdwTFrFbF7FOo%2BgnAkgOFtFBFnAvACgIAyQNFeF6FpAcAsASAEp3C9AZAFAEAMl52CQwAUgW8NAus6MlAMQfFMQ4QLQXwnAVFelzAxAXwAA8jENoCTkZbwBKXxgQOZRBIZWJaQFgOPMAG4GIOibZW5bxkPOIK5fgLRBArznxVSf5lBb5WjJha5feJoQZR4FgHxaPCwL5VbjEOkJgMeP5UYJBKAGJSsBWGbAoKaXgJgA3OZb8LhVRfwIICIGIOwFIDIIIIoCoOoK5boG0mBcYD%2BZYPoGPEJZACsM7K7JwMJOZTsLwFcfELcFgENRACsHYCTlkC4HllMJ0DHMEHlvMMMFUMkIUJkAIBtf4FtYdQ0LtRUCMEct0CtQIH0JMJ4B0KdbdRAvdRMAMFuAsNdWMB9SdWYFtbMK0JdYsEcktWsBsE1RhVhbxa5YRRwIRAEDqMJCmEcMAMgBqVIHcGEhALgIQMJpRUsLwKJVoKdKQAxUxSxexdTUxZxbFTxaQLhfhfDYJcJdRbRSsJJYgCgLLrJfEOQJQEpXJSgD1VwAEFwGYjjAQHwHQJedpbpfpWZb5SZQZZZdZQ4L5fZYwI5c5Xxe5V4J5d5UJdwLwFgBbHlVsPhcFStWFa5RFcgFFSbeQL5rFfhfFabGZUlZbcTbcGlU7RlVlTlebcAPlRzXwAYMAKVeVZVdVb5XVcIKIOIM1fHW1WoHxboKfEPCgH1TYPFQtSNShVBuNZNdNVbnNeXvAEtXUHdX4BAK4P9VtaEF9XtRIBoGdekEddkE9dMO3UUFkCDT9YDdXW9Y0H9d3Zta9Q0A9Z9WUC3UcoDWPbkBPUDTPUMFdftTHODeRVDVxRwNhYzXxfDYjcjajYPPGGLXcFwHcHYnwlpvEK7ORLjfgDKUnDsOCsTRzfRYxcxTTTTbvQzUzdNQJbYGzSTXRbvWYLDczcA2A2TVbhkM4JIEAA)

The sequence for finding the start of the next iteration:
```asm
        vpbroadcastd    zmm2, r10d
        vpbroadcastd    zmm3, edi
        vpcmpleud       k0, zmm0, zmm3
        vpcmpleud       k1, zmm1, zmm2
        kmovw   esi, k0
        lzcnt   esi, esi
        mov     ebx, 32
        sub     ebx, esi
        lea     rdi, [r9 + 4*rbx]
        kmovw   esi, k1
        lzcnt   esi, esi
        mov     r10d, 32
        sub     r10d, esi
        lea     rsi, [r11 + 4*r10]
```
It's a long dependency chain, and `vpbroadcastd` & `vpcmpleud` & `kmovw` have pretty high latencies, especially on Zen 4 (Icelake is a few cycles shorter).

With the old code, even passing in `-march=znver4 -mtune=znver4` isn't enough for the compilers to fully move this sequence before the intersection subroutine.

I don't think this is necessary for the `turin` kernel because its intersection subroutine is so much smaller.

I don't have an ARM CPU yet, but it's possible that the `neon` kernel could benefit from the same change.