### PR TITLE
Fix: Turin kernels for sparse dot products

### DIFF
--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -561,7 +561,7 @@ SIMSIMD_INTERNAL simsimd_f32_t _simsimd_mm256_reduce_add_ps_turin(__m256 v) {
     // 32
     high_v = _mm_shuffle_ps(low_v, low_v, 0b0000'0001);
     low_v = _mm_add_ps(low_v, high_v);
-    return low_v[0];
+    return _mm_cvtss_f32(low_v);
 }
 
 SIMSIMD_PUBLIC void simsimd_intersect_u16_turin(      //

--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -678,7 +678,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_weights_u16_turin(                  //
 
     // The baseline implementation for very small arrays (2 registers or less) can be quite simple:
     if (a_length < 64 && b_length < 64) {
-        simsimd_intersect_u16_serial(a, b, a_length, b_length, results);
+        simsimd_spdot_weights_u16_serial(a, b, a_weights, b_weights, a_length, b_length, results);
         return;
     }
 
@@ -751,9 +751,9 @@ SIMSIMD_PUBLIC void simsimd_spdot_weights_u16_turin(                  //
         a += a_step, a_weights += a_step;
         b += b_step, b_weights += b_step;
     }
-
-    simsimd_intersect_u16_serial(a, b, a_end - a, b_end - b, results);
-    *results += intersection_size;
+    simsimd_spdot_weights_u16_serial(a, b, a_weights, b_weights, a_end - a, b_end - b, results);
+    results[0] += intersection_size;
+    results[1] += _mm512_reduce_add_ps(_mm512_castps256_ps512(product_vec.ymmps));
 }
 
 SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_turin(                 //
@@ -764,7 +764,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_turin(                 //
 
     // The baseline implementation for very small arrays (2 registers or less) can be quite simple:
     if (a_length < 64 && b_length < 64) {
-        simsimd_intersect_u16_serial(a, b, a_length, b_length, results);
+        simsimd_spdot_counts_u16_serial(a, b, a_weights, b_weights, a_length, b_length, results);
         return;
     }
 
@@ -837,8 +837,9 @@ SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_turin(                 //
         b += b_step, b_weights += b_step;
     }
 
-    simsimd_intersect_u16_serial(a, b, a_end - a, b_end - b, results);
-    *results += intersection_size;
+    simsimd_spdot_counts_u16_serial(a, b, a_weights, b_weights, a_end - a, b_end - b, results);
+    results[0] += intersection_size;
+    results[1] += _mm512_reduce_add_epi32(_mm512_castsi256_si512(product_vec.ymm));
 }
 
 #pragma clang attribute pop

--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -533,37 +533,6 @@ SIMSIMD_PUBLIC void simsimd_intersect_u32_ice(        //
         "avx2,avx512f,avx512vl,bmi2,lzcnt,popcnt,avx512bw,avx512vbmi2,avx512bf16,avx512vnni,avx512vp2intersect"))), \
     apply_to = function)
 
-// Replacement for _mm512_reduce_add_epi32(_mm512_castsi256_si512(v)) because clang 17-19 miscompiles that.
-SIMSIMD_INTERNAL simsimd_u32_t _simsimd_mm256_reduce_add_epi32_turin(__m256i v) {
-    // 128
-    __m128i low_v = _mm256_castsi256_si128(v);
-    __m128i high_v = _mm256_extracti128_si256(v, 1);
-    low_v = _mm_add_epi32(low_v, high_v);
-    // 64
-    high_v = _mm_shuffle_epi32(low_v, 0b0000'1110);
-    low_v = _mm_add_epi32(low_v, high_v);
-    // 32
-    high_v = _mm_shuffle_epi32(low_v, 0b0000'0001);
-    low_v = _mm_add_epi32(low_v, high_v);
-    return _mm_cvtsi128_si32(low_v);
-}
-
-// Same issue as above, for ps.
-SIMSIMD_INTERNAL simsimd_f32_t _simsimd_mm256_reduce_add_ps_turin(__m256 v) {
-    // 128
-    __m128 low_v = _mm256_castps256_ps128(v);
-    __m128 high_v = _mm256_extractf128_ps(v, 1);
-    low_v = _mm_add_ps(low_v, high_v);
-    // 64
-    // float shuffles take 2 vecs, but we only need one
-    high_v = _mm_shuffle_ps(low_v, low_v, 0b0000'1110);
-    low_v = _mm_add_ps(low_v, high_v);
-    // 32
-    high_v = _mm_shuffle_ps(low_v, low_v, 0b0000'0001);
-    low_v = _mm_add_ps(low_v, high_v);
-    return _mm_cvtss_f32(low_v);
-}
-
 SIMSIMD_PUBLIC void simsimd_intersect_u16_turin(      //
     simsimd_u16_t const *a, simsimd_u16_t const *b,   //
     simsimd_size_t a_length, simsimd_size_t b_length, //
@@ -784,7 +753,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_weights_u16_turin(                  //
     }
     simsimd_spdot_weights_u16_serial(a, b, a_weights, b_weights, a_end - a, b_end - b, results);
     results[0] += intersection_size;
-    results[1] += _simsimd_mm256_reduce_add_ps_turin(product_vec.ymmps);
+    results[1] += _mm512_reduce_add_ps(_mm512_insertf32x8(_mm512_setzero_ps(), product_vec.ymmps, 0));
 }
 
 SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_turin(                 //
@@ -870,7 +839,7 @@ SIMSIMD_PUBLIC void simsimd_spdot_counts_u16_turin(                 //
 
     simsimd_spdot_counts_u16_serial(a, b, a_weights, b_weights, a_end - a, b_end - b, results);
     results[0] += intersection_size;
-    results[1] += _simsimd_mm256_reduce_add_epi32_turin(product_vec.ymm);
+    results[1] += _mm512_reduce_add_epi32(_mm512_inserti64x4(_mm512_setzero_si512(), product_vec.ymm, 0));
 }
 
 #pragma clang attribute pop


### PR DESCRIPTION
Fixes* `simsimd_spdot_counts_u16_turin` and `simsimd_spdot_weights_u16_turin`.

\*I don't have Zen 5 hardware, so I haven't tested this, but it's at least closer to being correct :).

Draft while I dig into the apparent mis-compilation by clang.
[Godbolt repro of likely compiler bug in context](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCAArKQADqgKhE4MHt6%2BekkpjgJBIeEsUTHxdpgOaUIETMQEGT5%2BXLaY9nkM1bUEBWGR0XG2NXUNWc0KQ93BvcX9sQCUtqhexMjsHOYAzMHI3lgA1CYbbngsLMEExMEAdAiH2CYaAIIPjwQAngmYWFR7XgwpwBC6D2yAQtT2KRYkPQAH0IgAOGEEQ5WJ7vT7fX7/PCAr4gsHECEnaEwvCSVRmJEol4vdFfTA/AFA/HgyEkvCI5EbVGvD70n5/Jl40Gs4knWFeTnUtF8zFC4EKBAkAhEqHi0lcABsVO5tNlDKx8ohSrqqpJXi1Op5dLlOOZ5zN6rwG0pXOt%2BoF2NxwIdbPVXhdVr1GINRtoAmAe3DRkdLFheE1kiDMpDnrDEajGb9cZhXkTyeeKf5exhcKoWtjsIi5e1bppRcxVHDTBV2dhVEDdYbBvQSwi9ErMKo%2Ba7hd5qcHeaTrbFOZSAC9MAWbaHZ%2B2R4P8ONDKsCzSzBtvlM9kIAJIAWTP54AIjDlHILAFT249sFaMft45TE9NkeQieLyvW9T1CAAVbAACVQkeAJXwYd9/0/PBvzHK8gLvB8nxfAA3VA8AVNcYQUBJewIGE0D%2BAgFFzS0lEuMQID2JjmJY1i9gAenYl4WLbGjaxBARxj2AAqJhSEnS0VTQf4VWEiJxLYxTmM47jmN4vBJIEmSRKYGEAHdMBxBAqPE9TNOkoS5P0wzgGMhRxJUp4eMIhclxVXT6CMAgEFMly8EXJE9giGFPOAbyFKU1jHMeZy1RzLcagYXdZOITAFC8WgqLmaUx02BJiCYYAWCYPYAHE3BfBIvEVGFUASdoFH3DZ8sK4qyoqvYhmATACAgcwzCYbCKX68T%2BsG1RYi4MwqBGg4zAGobJrMbDaFm/qIjOMw1vm2h52QQRtrMJIEn25F5tG%2BbxqWiI9MOq6puwja8C2865oWiapurLU1tiNxVMipSxsWh6GAYPA7uB5aEjMc5oiUBx%2Buyn8DxaoqSp2QxIxbC48AiLwCEwPYqsVRiAbJ8mKcpqmyZMX7/pLGFscuPGCdLKAup60nqe5nneZ52m/qcxSgYpUh7umsXIZW0gnrMfQ9sERI6tOyWPrMG7VaWx7Ns1z6a115bQbwA3sOh2HiHhs6zDmG3RrpoWmKYBIEloN4kVQA4NmvPYqD%2BSoBCRsdcPwwdiNI8ilkEaiLVrZZgi5ynoti81zME2SxIk/iLNk%2BTuaTtTCI0rO0506yjJMwci8C7OROCgzy/sjiuId0P/LcvYPMYMKfNbgKVWC0Lwqp/OmN4hKd3b4TUvSzKFDmA4AHYeXpzi9lAhBCYiJg7GPE4XcwNhBBbNIfZIPZsOiN4IWK2haA74gCreBQ9ggMw9lS4A8HGOG9jP%2BgFDniCQwQVCYAEcvCEEJpCfeIB6Z4B%2BBATuXkECexfImOampzCaiCiFLu3lUF7ETPPEwS96bJ3VGHVAZEKJRz4kRaIeAGIZ1zrpeutkK51xsnZcSSDu7iQHngnu08MpZRykpVKBBlgMDEcxEh156wxWUuxMAYA14b1Sq%2BZ%2BDAPbpVBJ1BAwQsbPxMJqDQMJThLRhDDQQcMKhkUwAkIuJiNDiQEK7fRhMXQAFoIiEHPrURhggVEr2UaooQHtgjfyYMCVAPxtA%2BEcTGbyxAli2T2C6PYjAcZpQ7u5TqJxMDiXfAAa0JgIPYp5Vh7ACEwUp4kDJ7D0nQVaLdOIqIhATBI%2BiUleDSRWLJlwcktg7vktgVx6a8RjtXEuwka66VcJ7b2JVrAd1wcgmRo9CJTKkjMmuwUFmHG9hEOaFgcGD1uLqFuvFXKBXNpbNIRE26LL2BoDZWIT4X2QIFEhPIlKlhYGYWImo8B7DeKcN55CczbN%2BN9WIFhYXyMuYotikzOS/HhLTCwLpaaIt%2BbIheSyYSfP4USio4l8oYC8A4UlpgkUsQpegKlZFPlXDBSwZ55iAVAvoQQRcKTHmAs1BAbKSL6Z6QMQORBJy9gVkOC%2BeZDBgRYKwUFaVsqjg4NcMQ0hLcWK6RZWyjlpxBUhXQOgcBAqgVQH%2BYKkFNdhJzCYCKvFbFgoGtOEarl2paBmotSkQV1rzG2q0pZOYERnUKKUqvU8NiLZ2MMe/TAn9v4W0aYQFBzjOWWOsQTON1KHFV2KgoYpzi4K4VoBfZ%2BJVwwqlicaLwVAmyGLIUojuiqBIsASAEhQglTIewaXpQwKoiAd2Dj6FU8CPEQnfKsZ%2BvYGBgA4LWi%2BxADBdOGWIWgVxxm6oLnFCUmldJnGkXSxSkzD3mKYKoZ5%2BqKhXBjpirgsQcUQr3SnfiwVj3PLdXeh9cLXmxFxS2zZ%2B66H90vdew5OCWV/vhc%2BwDOVgNNwqT8byUCZ05PnYu5d0Q108PQNhCeU6nYUvyowgmRM8KxqQ%2BKughNEEQYIZ%2B4IGCVXLMsOkt%2BcrVlasXi6yK7GrBexlZqHhZd2HGMsFB76p6Aa3uQKyj1UHOUmp9earwlqhUQBtUCu1MzHURt3WxI9V6b00vvbCuDL7ZOsTkUho9LGoPyYs5g/91n%2BMsVo5Kz9pnuMOYYKxsw2DjkrIydx/ZirtUecUiFqTwmtQkrYXZE50nME2aUj%2BhThrlPGu5Wpv1z0rXaaDbpkNskw2GeRZFHzkHhOZZc4%2B%2BDQGjOL3kS15jAWoP1dgwB5rY4o3sT2KEVAelGmE1qITEprQr4jrBBfCEqA2C/xXXhhbY2gEBbuXYqdH8v65sai1/5S0QW6WdJST5nrLHIGwp0qZBaXQMfdSwSrfzzHHZwWdmll2prkRuw4u7jiHv1bZS9xS/yi3FIrCZggoI0qMwYG7YIcISXFRhxvaihhEcMEZq%2BpiWafs5tsfmwHZgGOfeJR9wMFOsHQ9hxjhHpJse5ywT5tHcPMeM8ZpVpDq916Ey7Z8QkYge1aRqFMYEJUV1XzBlUilqxGUaP4ISTAqgkh1ATWhvYqO6ekB54Nlm62sNLr2CEPEfj1HsD12xfHlIIcR07dPABRBUoaYLVqCAW3/bY9cmJ7X6P4dY%2BR6sz5oO2IOlp/7mhZEkcheE5ymEx1Tq5gexH9nDOY/OuQ5eAAai%2BMEWiPaZsT4IbFpikOe/aI8xcKXhOp%2BolHznEREMtdXgEVA0S20KgMVQdyt8dutEwIRwQY2G6dQ9pr7cpo62a8%2Bc7kBSvCa9g1xvPYpEiYpMZQjFrk6GN%2B7hw3jPfGkMsR08C1ZSWqJfZy16016nNOBq9Xp7SDrWFcNEelxSr%2BG5X7j7l7UEP5x7d8o0pqI3chU68A9G8xML9qIQ9cdWJT8QVOFv8Ltr9VNfUNN/UitECysRIw1xM7JQ9qsCDL9UDf8b8ACgDHcYQwCIBWc6dICkdmESDYCKgiClIGUmVzNstyCTV0AEg9IAF0BQCScIBODqUntoC39WDkBEtpCaV2D8U2t%2BswcSsz8PJt4yIIgUlolRBv4lVeDuUlACAuAaDHF3dhIIBFRlRcCHUacINFC8c1CkCQpNC4QdD0A9CCYDDvYVMjCepTDaDLDrDTR7VsogsatHCGZTht5IdsFdJv4EhL1i1PUTVkBO16AzCpkIdHs702USUDBxh3D29PDNCvgojwdYiKxgpEjkjilUjuV0j94sjLQcjgdTgxNCitCPCvDyj4Dw8iJOlnkMkvESxdok8AxScrCtlOxHVBiHE6jM8VINgAAxCpZ%2BbyL%2BASB%2BOxQ4NY0ITAL4DYtKRwIwYJbfYfGooYqDEYsYhWMiSYqASZWYq4hYiHKIwTJzeYhIKQ0fawL4xI%2BA2LITI5b4uQv4uLUEwEmzOzH8K5FyEiKhCOSiaOWiBhJhfhX4iTcE7EnjdtUY5ghZUY3OYRWeIg0kqiTFXrGvb2CvB5VyN5CkxqOFLgHFGkksCxH7VKTfJcaJWEe7UnG3ciTQrA7UFIJaMQjfLgp7G2RDAlJqVGNqDGGMJmXGfGfnOqBUgqNGdqSqOqWqeqNIBQDgBYWgTgWIXgPwDgLQUgVATgP6KTDjHtZYKpTYHgUgAgTQE0hYYpEASQDQK4MwBeSQBeLgLgBeAATgXnhAjI0FEzNI4EkEtK9NtM4F4AUBABcU9OtJNNIDgFgCQDQE7TozIAoAgCLMcXoBiGACkDlhoEyjhkoAiBTN8WYGIDeE4HdNbNqDeAAHkIhtA7FOzeAizD4CBez4IOyczSAsA8ZgA3BN0MzuBeAsBiojBxBpz8BUpKhK0UyVcKh1ThzyAbEEybT3xtCeyPAsAUycYWAjyV0IhkhMBrwD5MYEJQAcyFgmxCoFBs88BMA9JezPgrT3T%2BBBARAxB2ApAZBBBFAVB1BpzdBmgDAjAUB/jLB9BcYMzIAFg6oGpOAvFeyNheBUAV1LgsBsLhUWg2g0gXBFURgmhSBAgpgigShshkhUgBAGL2Lcg0gehWL%2BgxgB8vdOhhhPBGg9BygRKJh%2BK%2BgYgxgJhuKFKuhZKZh5KFhnSVgoLTTzTkzpy7SOA9hVB4RNQvF0FgBkBkAZVJBAyX5cBCAz43S5heBsytBbZfSgsrgNgIyuAIzYhJATL4QF4F5TF/L9BOAkzSArSbSDL0zMyPSvSFh8zEAUBFtKzohyBKAKySyUAUKaz4QuBt46ICA%2BA6B9smyWzggeyjzuz2z%2BzByHAjzRyskJzXYUzZzekFzb4lz3TVy3y1gbStz41dzpz9zkBDzlzjyCZTzeBzyCp2yryBqXLLg7zJqHynyXy1zgB3zEq%2BADBgBfz/zALgKjywLhBRBxBoKzq4K1AUzdA5Y8q0LHSbBzzKLcLDTBICKiKSKyL8I0p4ANLhL2g6L3BxKsgF4mLFVVK2KuANhmgchOL0gwa/AIaEb2hobBK4bqL40BBRL6hkaQAIapL2g8aMb5KsbJ98bMgUbBgVKWK5KJA4aNKlgtKJAdKOALSoqUyDKjKTKzLJAQQ8qZV4QrguArgNAX4irogGp54IB7K58nKXLEqfSQANgNgvK1bNatatbwrEy9KYq0zbB4rXLvTdazB9aSLDaTbbYV0UhnBJAgA) on line 131 of the clang output.

[Smaller repro of bug, runs on icelake](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM9KuADJ4DJgAcj4ARpjE/gCspAAOqAqETgwe3r7%2B0ilpjgIhYZEsMXFmiXaYDhlCBEzEBFk%2BfgG2mPaFDPWNBMUR0bEJtg1NLTntCmP9oYNlw5UAlLaoXsTI7BzmAMyhyN5YANQmO254LCyhBMShAHQIp9gmGgCCu/uHmCdnTtPEmFYTxe7zeuySxCYwBYTCOAHE3G4jkkvAoEAB9VBJboKEHgyHQ2EIpFjYCYAgQcxmJgAN1UZippBOZmpdPiXDMVEZzNZqnZZhptG5VKiVwZLKZVNoAC9kIJhSyUkk5QQFbz%2BVEAO5q2l8jk00V4cVmJZ4sw7CFQmFHA6GYBHJgEG54KJeAjfFFoiDo9GO52u90%2BqCk8mUlm6sykXX8qhRtn62ikQ2RmUq5JYtPRjlauN6gXJqlLIuS%2BJuEFHCuVqvVmu1h1JJK0ACe6KIPwAIkcqF4GLUBKawW8e2lgGF0EdrkdMKpWI3MOj%2Bd70Sx%2BXgjjSlicAOxWN5VgEEdYMI7Llcc9EA9BeTa%2B9DodGYJJ4HZmCAb06795b9t4ocMEdjhOghTjOLBzuilQAGxLiwUFrhu26fvu5JHielz8hemBXjeTB3g%2BT4vt66HnqI0xpFB6JpIuG6mjsn4mN%2Bv6vJOMKhBAm4MUhlYAPTcUcAAqADy7aCSARwEAgeAKEcVzAAgBBHGSCloP%2BDTAfwtBYOOTCakwTZAUcCioGwNrGU%2B9DEAoTI0Aw45RAYyAANZRKgqgyTUCCGFJLBdiQNoNkcECot8jTALiOwAGIDq8VbDngo5YUBClRCY8QWAAHKlnanNlO5cKQ%2BWFUyRWFQxP50eWlZxQl46TjSHYgbO9AQfE0GnhRtCoLhXiUUarVQD6sGtXgABUm5REWH6VRW0zoCAKBrAppxlmc64/PRjGDu85qWoSNoGEYDpOrcAYeliZoWgS1rEsiWKYtiGQKBwKy0Jw8S8H4HBaKQqCcGWljWIZawbN8uw8KQBCaM9KyOSAOw7Hc8NI8jKOQfonCSB9UM/ZwvAKCAGgQ1DKxwLASBoGBdCxOQlAU%2BZwzAFIkY0LQ7qWZQUTY1EoSNE2nDg9zzDEE2glRNoNSQ9wvAU2wgiCQwzbY1grrAG4Yi0PjUukFgMJGOIX28PgAK1DSmCa99041G6Wzg9cnTY7QLqQsLHhYNjzosPzvCm8QLlKO2mC68AjtGMTfAGGFABqeCYJqglJIwXsyIIIhiOwUjJ/IShqNjuj5QdxjWNY%2BguvjkArFiOKcAAtIJOy8KgPu3FgZfsR0XQZC4tkTH4%2BXBHMpTlHo%2BTpAIPfD6ko8MAMg/DPl1R9j0Mzj/PnQS3UMwz0McTz8vnitHo0x9FvCw7ysRnrJsEgvW9WMGzjHBHKo6WQdXkGSIpyDIEcUh3GYgW4EIH5MGSxeCSy0MWWG8NEYo1gfDNGr0OCY1IJ9b6v0OB4wJkTA2JMYCIAWpTCyNMIB0ypnEW0RguAAE4uBMAUEoJofA6Bs3xhATm99Ba8yTpw4WotxYOCTjLRgBB5aK3vsrLwqt1aa3BjrO0%2BtvpG3Xqbc2vBLbIGtknO2iDvqOyiM7JsrstjfQ9knH2ftMAByDiHUAODw5QgUNHWO8dE5a34CnUQ4gM7uKziodQ99dApjtCgIulgS5RFbhXB6AhNa13rj9JueAW7wHPmvReXd3D7xyH3WyJ8h75RHt0Fe6YCgZDyXPdu68BC9HGFk3ulTF41NmCUbeh897ZHqUfJo5Sz6rEvunG%2BHB3ooOxugp%2BL834fwofaahdwuB3A0IFOhDCcSbggIAogxBmQ7C4KA7BECYZwwRnAuBCCMZ3zQbjWwWDwHQ3RhwMwFyG5XNucWH2aRnCSCAA)

Most likely, I just need to handwrite a routine for `_mm256_reduce_add_epi32`.