### PR TITLE
Fix: Types in sparse dot-products generic macro

### DIFF
--- a/include/simsimd/sparse.h
+++ b/include/simsimd/sparse.h
@@ -187,8 +187,8 @@ SIMSIMD_MAKE_INTERSECT_LINEAR(accurate, u32, size) // simsimd_intersect_u32_accu
             simsimd_##input_type##_t ai = a[i];                                                                   \
             simsimd_##input_type##_t bj = b[j];                                                                   \
             int matches = ai == bj;                                                                               \
-            simsimd_##counter_type##_t awi = load_and_convert(a_weights + i);                                     \
-            simsimd_##counter_type##_t bwi = load_and_convert(b_weights + i);                                     \
+            simsimd_##accumulator_type##_t awi = load_and_convert(a_weights + i);                                 \
+            simsimd_##accumulator_type##_t bwi = load_and_convert(b_weights + i);                                 \
             weights_product += matches * awi * bwi;                                                               \
             intersection_size += matches;                                                                         \
             i += ai < bj;                                                                                         \


### PR DESCRIPTION
Re: types
The dot-product intrinsics [_mm256_dpbf16_ps](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_dpbf&ig_expand=2668), [_mm256_dpwssd_epi32](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#ig_expand=2958,5994,4584,5994,2227,5994,2938,5994,6047,3674,4920,2244,691,691,3878,3859,3850,2731,2675,2677,2679,2681,2731,2718&techs=AVX_ALL,AVX_512&text=_mm256*dpwssd*_epi32), and [svbfdot_f32](
https://docsmirror.github.io/A64/2023-06/bfdot_z_zzz.html) each widen the values before multiplying them, so the scalar algorithm should also do that. Also, the macro currently uses the `counter_type`, which is an unsigned int.

---

Re: saturating addition
Same links, none of them perform saturating addition other than the currently used `_mm256_dpwssds_epi32`, so the current `spdot_counts_u16_turin` kernel is the odd one out.
