### PR TITLE
L2 (Euclidean) distance in Swift 

### DIFF
--- a/swift/SimSIMD.swift
+++ b/swift/SimSIMD.swift
@@ -4,6 +4,7 @@ public protocol SimSIMD {
     static var dataType: simsimd_datatype_t { get }
     static var cosine: simsimd_metric_dense_punned_t { get }
     static var dotProduct: simsimd_metric_dense_punned_t { get }
+    static var euclidean: simsimd_metric_dense_punned_t { get }
     static var squaredEuclidean: simsimd_metric_dense_punned_t { get }
 }
 
@@ -11,6 +12,7 @@ extension Int8: SimSIMD {
     public static let dataType = simsimd_datatype_i8_k
     public static let cosine = find(kind: simsimd_metric_cosine_k, dataType: dataType)
     public static let dotProduct = find(kind: simsimd_metric_dot_k, dataType: dataType)
+    public static let euclidean = find(kind: simsimd_metric_euclidean_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 
@@ -20,6 +22,7 @@ extension Float16: SimSIMD {
     public static let dataType = simsimd_datatype_f16_k
     public static let cosine = find(kind: simsimd_metric_cosine_k, dataType: dataType)
     public static let dotProduct = find(kind: simsimd_metric_dot_k, dataType: dataType)
+    public static let euclidean = find(kind: simsimd_metric_euclidean_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 #endif
@@ -28,6 +31,7 @@ extension Float32: SimSIMD {
     public static let dataType = simsimd_datatype_f32_k
     public static let cosine = find(kind: simsimd_metric_cosine_k, dataType: dataType)
     public static let dotProduct = find(kind: simsimd_metric_inner_k, dataType: dataType)
+    public static let euclidean = find(kind: simsimd_metric_euclidean_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 
@@ -35,6 +39,7 @@ extension Float64: SimSIMD {
     public static let dataType = simsimd_datatype_f64_k
     public static let cosine = find(kind: simsimd_metric_cosine_k, dataType: dataType)
     public static let dotProduct = find(kind: simsimd_metric_dot_k, dataType: dataType)
+    public static let euclidean = find(kind: simsimd_metric_euclidean_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 
@@ -47,6 +52,11 @@ extension SimSIMD {
     @inlinable @inline(__always)
     public static func dot<A, B>(_ a: A, _ b: B) -> Double? where A: Sequence, B: Sequence, A.Element == Self, B.Element == Self {
         perform(dotProduct, a: a, b: b)
+    }
+
+    @inlinable @inline(__always)
+    public static func euclidean<A, B>(_ a: A, _ b: B) -> Double? where A: Sequence, B: Sequence, A.Element == Self, B.Element == Self {
+        perform(euclidean, a: a, b: b)
     }
 
     @inlinable @inline(__always)
@@ -64,6 +74,11 @@ extension RandomAccessCollection where Element: SimSIMD {
     @inlinable @inline(__always)
     public func dot<B>(_ b: B) -> Double? where B: Sequence, B.Element == Element {
         Element.dot(self, b)
+    }
+
+    @inlinable @inline(__always)
+    public func euclidean<B>(_ b: B) -> Double? where B: Sequence, B.Element == Element {
+        Element.euclidean(self, b)
     }
 
     @inlinable @inline(__always)

--- a/swift/SimSIMD.swift
+++ b/swift/SimSIMD.swift
@@ -14,6 +14,7 @@ extension Int8: SimSIMD {
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 
+#if !arch(x86_64)
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Float16: SimSIMD {
     public static let dataType = simsimd_datatype_f16_k
@@ -21,6 +22,7 @@ extension Float16: SimSIMD {
     public static let dotProduct = find(kind: simsimd_metric_dot_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
+#endif
 
 extension Float32: SimSIMD {
     public static let dataType = simsimd_datatype_f32_k

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -66,6 +66,36 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 32.0, accuracy: 0.01)
     }
 
+    func testEuclideanInt8() throws {
+        let a: [Int8] = [1, 2, 3]
+        let b: [Int8] = [4, 5, 6]
+        let result = try XCTUnwrap(a.euclidean(b))
+        XCTAssertEqual(result, 5.196152422706632, accuracy: 0.01)
+    }
+
+    #if !arch(x86_64)
+    func testEuclideanFloat16() throws {
+        let a: [Float16] = [1.0, 2.0, 3.0]
+        let b: [Float16] = [4.0, 5.0, 6.0]
+        let result = try XCTUnwrap(a.euclidean(b))
+        XCTAssertEqual(result, 5.196152422706632, accuracy: 0.01)
+    }
+    #endif
+
+    func testEuclideanFloat32() throws {
+        let a: [Float32] = [1.0, 2.0, 3.0]
+        let b: [Float32] = [4.0, 5.0, 6.0]
+        let result = try XCTUnwrap(a.euclidean(b))
+        XCTAssertEqual(result, 5.196152422706632, accuracy: 0.01)
+    }
+
+    func testEuclideanFloat64() throws {
+        let a: [Float64] = [1.0, 2.0, 3.0]
+        let b: [Float64] = [4.0, 5.0, 6.0]
+        let result = try XCTUnwrap(a.euclidean(b))
+        XCTAssertEqual(result, 5.196152422706632, accuracy: 0.01)
+    }
+
     func testSqeuclideanInt8() throws {
         let a: [Int8] = [1, 2, 3]
         let b: [Int8] = [4, 5, 6]

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -13,12 +13,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 0.00012027938, accuracy: 0.01)
     }
 
+    #if !arch(x86_64)
     func testCosineFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [1.0, 2.0, 3.0]
         let result = try XCTUnwrap(a.cosine(b))
         XCTAssertEqual(result, 0.004930496, accuracy: 0.01)
     }
+    #endif
 
     func testCosineFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]
@@ -41,12 +43,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 32.0, accuracy: 0.01)
     }
 
+    #if !arch(x86_64)
     func testDotFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [4.0, 5.0, 6.0]
         let result = try XCTUnwrap(a.dot(b))
         XCTAssertEqual(result, 32.0, accuracy: 0.01)
     }
+    #endif
 
     func testDotFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]
@@ -69,12 +73,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 27.0, accuracy: 0.01)
     }
 
+    #if !arch(x86_64)
     func testSqeuclideanFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [4.0, 5.0, 6.0]
         let result = try XCTUnwrap(a.sqeuclidean(b))
         XCTAssertEqual(result, 27.0, accuracy: 0.01)
     }
+    #endif
 
     func testSqeuclideanFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]


### PR DESCRIPTION
Implements https://github.com/ashvardanian/SimSIMD/issues/203

Additionally, guards usage of `Float16` under `#if !arch(x86_64)`, as `Float16` is not available on Intel Macs - [documentation](https://developer.apple.com/documentation/swift/float16#overview), [implementation](https://github.com/swiftlang/swift/blob/53b34604d087c91eb59f22ba28dd892383c61526/stdlib/public/core/FloatingPointTypes.swift.gyb#L71). Without this change I couldn't build SimSIMD Swift package on my Intel Mac.

## Testing
Ran `swift build && swift test -v`:

```
Apple Swift version 6.0.3 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)
Target: x86_64-apple-macosx10.13
...
Test Suite 'SimSIMDTests' passed at 2025-02-26 09:18:20.429.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.006 (0.007) seconds
Test Suite 'SimSIMDPackageTests.xctest' passed at 2025-02-26 09:18:20.429.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.006 (0.007) seconds
```