### PR TITLE
Fix(cmake): Use relative install paths for Termux compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,5 +132,5 @@ if (SIMSIMD_BUILD_SHARED)
     )
 endif ()
 
-install(DIRECTORY ./include/ DESTINATION /usr/include/)
-install(DIRECTORY ./c/ DESTINATION /usr/src/${PROJECT_NAME}/)
+install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY c/ DESTINATION share/doc/${PROJECT_NAME}/src)


### PR DESCRIPTION
This PR fixes #287.

The `install()` commands in `CMakeLists.txt` were using hardcoded absolute paths (`/usr/include` and `/usr/src`), which caused build failures on non-standard environments like Termux.

This change replaces the absolute paths with relative destinations (`include` and `share/doc/${PROJECT_NAME}/src`). This makes the installation respect the `CMAKE_INSTALL_PREFIX` variable, allowing the project to be built and installed correctly on Termux and other similar systems.