### PR TITLE
Fix: Replace avx2vnni with avxvnni for GCC and Clang compatibility

### DIFF
--- a/include/simsimd/dot.h
+++ b/include/simsimd/dot.h
@@ -1819,8 +1819,8 @@ simsimd_dot_u8_ice_cycle:
 
 #if SIMSIMD_TARGET_SIERRA
 #pragma GCC push_options
-#pragma GCC target("avx2", "bmi2", "avx2vnni")
-#pragma clang attribute push(__attribute__((target("avx2,bmi2,avx2vnni"))), apply_to = function)
+#pragma GCC target("avx2", "bmi2", "avxvnni")
+#pragma clang attribute push(__attribute__((target("avx2,bmi2,avxvnni"))), apply_to = function)
 
 SIMSIMD_PUBLIC void simsimd_dot_i8_sierra(simsimd_i8_t const *a_scalars, simsimd_i8_t const *b_scalars,
                                           simsimd_size_t count_scalars, simsimd_distance_t *result) {

--- a/include/simsimd/spatial.h
+++ b/include/simsimd/spatial.h
@@ -2290,8 +2290,8 @@ simsimd_cos_i4x2_ice_cycle:
 
 #if SIMSIMD_TARGET_SIERRA
 #pragma GCC push_options
-#pragma GCC target("avx2", "bmi2", "avx2vnni")
-#pragma clang attribute push(__attribute__((target("avx2,bmi2,avx2vnni"))), apply_to = function)
+#pragma GCC target("avx2", "bmi2", "avxvnni")
+#pragma clang attribute push(__attribute__((target("avx2,bmi2,avxvnni"))), apply_to = function)
 
 SIMSIMD_PUBLIC void simsimd_cos_i8_sierra(simsimd_i8_t const *a, simsimd_i8_t const *b, simsimd_size_t n,
                                           simsimd_distance_t *result) {


### PR DESCRIPTION
## Related Issue
issue #295 

## Summary
Fixes compiler compatibility by correcting the pragma target attribute from avx2vnni to avxvnni for GCC and Clang compilers.


## Problem
The target attribute name `avx2vnni` is incorrect. The correct name is `avxvnni` (AVX-VNNI instruction set extension). This typo could cause compilation errors with certain compiler versions.

## Solution
Replaced all occurrences of `avx2vnni` with `avxvnni` in Sierra target pragma directives across both files.
