### PR TITLE
Fix: Initialize dummy_input in simsimd_capabilities to fix MSan false positive

### DIFF
--- a/c/lib.c
+++ b/c/lib.c
@@ -274,7 +274,7 @@ SIMSIMD_DYNAMIC simsimd_capability_t simsimd_capabilities(void) {
 
     // Passing `NULL` as `x` will trigger all kinds of `nonull` warnings on GCC.
     typedef double largest_scalar_t;
-    largest_scalar_t dummy_input[1];
+    largest_scalar_t dummy_input[1] = {0};
     void *x = &dummy_input[0];
 
     // Dense:


### PR DESCRIPTION
## Summary

`simsimd_capabilities` probes SIMD instructions with an uninitialized `dummy_input` buffer and `n=0`. SVE implementations (e.g. `simsimd_cos_f32_sve`) use `do { ... } while` loops that always execute the body once. MemorySanitizer doesn't understand SVE predicated loads and reports use-of-uninitialized-value false positives.

The fix simply initializes the buffer to zero: `largest_scalar_t dummy_input[1] = {0};`

## Context

Discovered during ClickHouse CI stress testing with MSan on ARM (aarch64).