### PR TITLE
Fix: Enlarge dummy buffer for SVE predicated loads to fix MSan false positive

### DIFF
--- a/c/lib.c
+++ b/c/lib.c
@@ -273,8 +273,11 @@ SIMSIMD_DYNAMIC simsimd_capability_t simsimd_capabilities(void) {
     simsimd_distance_t *dummy_results = &dummy_results_buffer[0];
 
     // Passing `NULL` as `x` will trigger all kinds of `nonull` warnings on GCC.
+    // The buffer must be large enough to cover the widest SIMD register (SVE: up to 2048 bits = 256 bytes).
+    // SVE functions use `do { } while (i < n)` loops that execute once even with n=0, and MemorySanitizer
+    // instruments predicated loads as full-width reads, so all bytes must be initialized.
     typedef double largest_scalar_t;
-    largest_scalar_t dummy_input[1] = {0};
+    largest_scalar_t dummy_input[32] = {0};
     void *x = &dummy_input[0];
 
     // Dense:


### PR DESCRIPTION
## Summary

`simsimd_capabilities` probes SIMD functions with `n=0` to pre-initialize dispatch function pointers. SVE implementations use `do { } while (i < n)` loops that always execute the body once, even with `n=0`. MemorySanitizer instruments SVE predicated loads (`svld1_f32` etc.) as full-width vector reads regardless of the predicate mask, so it reports use-of-uninitialized memory when the buffer is smaller than the SIMD register width.

Increase the dummy buffer from 8 bytes (`double[1]`) to 256 bytes (`double[32]`) to cover the widest possible SVE vector (2048 bits).

This is a follow-up to #302 which initialized the buffer to zero but kept it at only 1 element.

CI report from ClickHouse's ARM MSan stress test: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98677&sha=a1b9d7f6170c510431fce962a869aa617d88d888&name_0=PR&name_1=Stress%20test%20%28arm_msan%29