### PR TITLE
Fix: Include `<unistd.h>` for ARM POSIX capability detection

### DIFF
--- a/include/numkong/capabilities.h
+++ b/include/numkong/capabilities.h
@@ -117,6 +117,9 @@
 // Detect POSIX extensions availability for signal handling.
 // POSIX extensions provide `sigaction`, `sigjmp_buf`, and `sigsetjmp` for safe signal handling.
 // These are needed on Linux ARM for safely testing `mrs` instruction availability.
+#if defined(NK_DEFINED_LINUX_) || defined(NK_DEFINED_FREEBSD_)
+#include <unistd.h> // `_POSIX_VERSION`
+#endif
 #if (defined(NK_DEFINED_LINUX_) || defined(NK_DEFINED_FREEBSD_)) && defined(_POSIX_VERSION)
 #include <setjmp.h> // `sigjmp_buf`, `sigsetjmp`, `siglongjmp`
 #include <signal.h> // `sigaction`, `SIGILL`


### PR DESCRIPTION
`_POSIX_VERSION` is defined by `<unistd.h>`, which was never included after https://github.com/ashvardanian/NumKong/commit/b139cc920df15eb6d69d61deb25e2a0cb8fc1fc2. The check `(defined(NK_DEFINED_LINUX_) || defined(NK_DEFINED_FREEBSD_)) && defined(_POSIX_VERSION)` always evaluated to false, so `NK_HAS_POSIX_EXTENSIONS_` was always 0. This caused `nk_capabilities_arm_()` to take the fallback path, returning only `nk_cap_neon_k | nk_cap_serial_k` and skipping detection of all other ARM capabilities.

Test:
```c
#include <stdio.h>
#define NK_DYNAMIC_DISPATCH 0
#include <numkong/numkong.h>

int main() {
    printf("NK_HAS_POSIX_EXTENSIONS_ = %d\n", NK_HAS_POSIX_EXTENSIONS_);
    nk_capability_t caps = nk_capabilities_arm_();
    printf("capabilities = 0x%x\n", (unsigned)caps);
    printf("neonbfdot: %d\n", !!(caps & nk_cap_neonbfdot_k));
    printf("sve: %d\n", !!(caps & nk_cap_sve_k));
    return 0;
}
```
Before fix: `NK_HAS_POSIX_EXTENSIONS_ = 0`
After fix: `NK_HAS_POSIX_EXTENSIONS_ = 1`

Exact capabilities depend on hardware. On my machine all were 1.