### PR TITLE
Fix use-of-uninitialized-value in SVE accumulator operations

### DIFF
--- a/include/numkong/spatial/sve.h
+++ b/include/numkong/spatial/sve.h
@@ -219,8 +219,8 @@ NK_PUBLIC void nk_angular_f64_sve(nk_f64_t const *a, nk_f64_t const *b, nk_size_
         ab_compensation_f64x = svadd_f64_x(predicate_f64x, ab_compensation_f64x,
                                            svadd_f64_x(predicate_f64x, sum_error_f64x, product_error_f64x));
         // Simple FMA for self-products (no cancellation)
-        a2_f64x = svmla_f64_x(predicate_f64x, a2_f64x, a_f64x, a_f64x);
-        b2_f64x = svmla_f64_x(predicate_f64x, b2_f64x, b_f64x, b_f64x);
+        a2_f64x = svmla_f64_m(predicate_f64x, a2_f64x, a_f64x, a_f64x);
+        b2_f64x = svmla_f64_m(predicate_f64x, b2_f64x, b_f64x, b_f64x);
         i += svcntd();
     } while (i < n);
 


### PR DESCRIPTION
## Summary

Use `_m` (merge) instead of `_x` (don't-care) for SVE multiply-accumulate operations (`svmla`, `svmls`) on accumulator vectors in `spatial.h` and `dot.h`.

The `_x` variant leaves inactive lanes undefined when the predicate is false (i.e., for elements past the end of the input array). However, the final horizontal reduction `svaddv` uses `svptrue` (all lanes active), which sums **all** lanes — including those with undefined values from `_x`. This causes MemorySanitizer to report use-of-uninitialized-value when the input vector length is not a multiple of the SVE register width.

The `_m` (merge) variant preserves the first operand (the accumulator) for inactive lanes, keeping them at their initialized zero value. This is correct because:
- Accumulators start at 0
- Active lanes accumulate normally
- Inactive lanes retain 0 (or their previous accumulated value)
- The final `svaddv(svptrue, ...)` correctly sums all lanes

### Affected functions

**spatial.h**: `simsimd_l2sq_f32_sve`, `simsimd_cos_f32_sve`, `simsimd_l2sq_f64_sve`, `simsimd_cos_f64_sve`, `simsimd_l2sq_f16_sve`, `simsimd_cos_f16_sve`, `simsimd_l2sq_bf16_sve`

**dot.h**: `simsimd_dot_f32_sve`, `simsimd_dot_f32c_sve`, `simsimd_vdot_f32c_sve`, `simsimd_dot_f64_sve`, `simsimd_dot_f64c_sve`, `simsimd_vdot_f64c_sve`, `simsimd_dot_f16_sve`, `simsimd_dot_f16c_sve`, `simsimd_vdot_f16c_sve`

### Reproduction

Detected as `MemorySanitizer: use-of-uninitialized-value` in `simsimd_cos_f32_sve` during ClickHouse CI stress tests on ARM with MSan.