### PR TITLE
Fix: SwiftPM build for header-only CNumKong target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
         .target(
             name: "CNumKong",
             path: "include",
+            sources: ["_dummy.c"],
             publicHeadersPath: ".",
             cSettings: [
                 .define("NK_DYNAMIC_DISPATCH", to: "1"),

--- a/include/_dummy.c
+++ b/include/_dummy.c
@@ -1,0 +1,14 @@
+// SwiftPM workaround for header-only CNumKong target.
+//
+// Upstream NumKong's Package.swift declares CNumKong as header-only:
+//   .target(name: "CNumKong", path: "include", publicHeadersPath: ".")
+// SwiftPM/Xcode 16+ refuses to build header-only C targets when they are
+// transitive dependencies of an app target — the link step expects a
+// CNumKong.o output that is never produced.
+//
+// See https://github.com/swiftlang/swift-package-manager/issues/5706
+//
+// This file is a no-op compile unit added solely so the target produces
+// at least one .o for the relocatable link to consume. It does not affect
+// runtime behaviour.
+static int _cnumkong_swiftpm_dummy __attribute__((unused));


### PR DESCRIPTION
SwiftPM/Xcode 16 cannot build a header-only C target that ends up as a transitive dependency of an app target — the link step expects a CNumKong.o output that is never produced because the target has no sources to compile.

Add a no-op _dummy.c to satisfy the linker, with no runtime effect.

Refs https://github.com/swiftlang/swift-package-manager/issues/5706