### PR TITLE
Add Haswell sparse dot kernel

### DIFF
--- a/bench/bench_sparse.cpp
+++ b/bench/bench_sparse.cpp
@@ -187,6 +187,10 @@ void bench_sparse_dot() {
     run_sparse_dot<u32_k, f32_k>("sparse_dot_u32f32_icelake", nk_sparse_dot_u32f32_icelake);
 #endif
 
+#if NK_TARGET_HASWELL
+    run_sparse_dot<u32_k, f32_k>("sparse_dot_u32f32_haswell", nk_sparse_dot_u32f32_haswell);
+#endif
+
 #if NK_TARGET_TURIN
     run_sparse_dot<u16_k, bf16_k>("sparse_dot_u16bf16_turin", nk_sparse_dot_u16bf16_turin);
     run_sparse_dot<u32_k, f32_k>("sparse_dot_u32f32_turin", nk_sparse_dot_u32f32_turin);

--- a/c/dispatch_f32.c
+++ b/c/dispatch_f32.c
@@ -246,6 +246,7 @@ void nk_dispatch_f32_find_(nk_capability_t v, nk_kernel_kind_t k, nk_kernel_punn
             return;
         case nk_kernel_maxsim_pack_k: *m = (m_t)&nk_maxsim_pack_f32_haswell, *c = nk_cap_haswell_k; return;
         case nk_kernel_maxsim_packed_k: *m = (m_t)&nk_maxsim_packed_f32_haswell, *c = nk_cap_haswell_k; return;
+        case nk_kernel_sparse_dot_k: *m = (m_t)&nk_sparse_dot_u32f32_haswell, *c = nk_cap_haswell_k; return;
         default: break;
         }
 #endif

--- a/include/numkong/sparse.h
+++ b/include/numkong/sparse.h
@@ -20,7 +20,7 @@
  *  For hardware architectures:
  *
  *  - Arm: NEON, SVE2
- *  - x86: Ice Lake, Turin
+ *  - x86: Haswell, Ice Lake, Turin
  *
  *  @section intersection_algorithm Intersection by Merge
  *
@@ -236,6 +236,13 @@ NK_PUBLIC void nk_sparse_dot_u32f32_icelake(nk_u32_t const *a, nk_u32_t const *b
                                             nk_f64_t *product);
 #endif // NK_TARGET_ICELAKE
 
+#if NK_TARGET_HASWELL
+/** @copydoc nk_sparse_dot_u32f32 */
+NK_PUBLIC void nk_sparse_dot_u32f32_haswell(nk_u32_t const *a, nk_u32_t const *b, nk_f32_t const *a_weights,
+                                            nk_f32_t const *b_weights, nk_size_t a_length, nk_size_t b_length,
+                                            nk_f64_t *product);
+#endif // NK_TARGET_HASWELL
+
 #if NK_TARGET_TURIN
 /** @copydoc nk_sparse_intersect_u16 */
 NK_PUBLIC void nk_sparse_intersect_u16_turin(nk_u16_t const *a, nk_u16_t const *b, nk_size_t a_length,
@@ -274,6 +281,7 @@ NK_INTERNAL nk_dtype_t nk_sparse_dot_output_dtype(nk_dtype_t dtype) {
 #include "numkong/sparse/serial.h"
 #include "numkong/sparse/neon.h"
 #include "numkong/sparse/sve2.h"
+#include "numkong/sparse/haswell.h"
 #include "numkong/sparse/icelake.h"
 #include "numkong/sparse/turin.h"
 
@@ -349,6 +357,8 @@ NK_PUBLIC void nk_sparse_dot_u32f32(nk_u32_t const *a, nk_u32_t const *b, nk_f32
     nk_sparse_dot_u32f32_turin(a, b, a_weights, b_weights, a_length, b_length, product);
 #elif NK_TARGET_ICELAKE
     nk_sparse_dot_u32f32_icelake(a, b, a_weights, b_weights, a_length, b_length, product);
+#elif NK_TARGET_HASWELL
+    nk_sparse_dot_u32f32_haswell(a, b, a_weights, b_weights, a_length, b_length, product);
 #else
     nk_sparse_dot_u32f32_serial(a, b, a_weights, b_weights, a_length, b_length, product);
 #endif

--- a/include/numkong/sparse/README.md
+++ b/include/numkong/sparse/README.md
@@ -58,12 +58,6 @@ Match counts are extracted via `_mm_popcnt_u32` on the comparison masks, accumul
 Before each 16x16 comparison block, a fast overlap check (`a_max < b_min || b_max < a_min`) skips non-overlapping register loads entirely — critical for sparse workloads where most pairs have disjoint index ranges.
 No native `_mm512_2intersect_epi16` instruction exists in any x86 ISA — UInt16 intersection must convert indices to UInt32 before comparison, halving effective throughput.
 
-### Rank-and-Permute Sparse Dot on Haswell
-
-`nk_sparse_dot_u32f32_haswell` targets AVX2, which has neither `VP2INTERSECT` nor mask-compress, so it intersects a block of 16 A indices against 8 B indices by _rank_: for each A lane it counts how many B indices are strictly smaller (seven `VPCMPGTD` comparisons against sign-biased lanes, split across even/odd accumulators to shorten the dependency chain).
-That count is the position of the candidate match, fed straight to `_mm256_permutevar8x32_epi32` to gather the aligned B index and weight; a `VPCMPEQD` confirms the match and masks both weights to zero on a miss, so the widening `_mm256_fmadd_pd` accumulation cannot be poisoned by NaN or Inf weights.
-Highly imbalanced inputs (`longer > 64 * shorter`) take a galloping path instead, and the unaligned remainder is finished by the scalar merge.
-
 ### VP2INTERSECT on AMD Turin
 
 `nk_sparse_intersect_u32_turin` uses the `VP2INTERSECT` instruction (Zen5), which produces _two_ 16-bit masks in a single operation — one indicating which elements of A matched any element of B, and vice versa.

--- a/include/numkong/sparse/README.md
+++ b/include/numkong/sparse/README.md
@@ -58,6 +58,12 @@ Match counts are extracted via `_mm_popcnt_u32` on the comparison masks, accumul
 Before each 16x16 comparison block, a fast overlap check (`a_max < b_min || b_max < a_min`) skips non-overlapping register loads entirely — critical for sparse workloads where most pairs have disjoint index ranges.
 No native `_mm512_2intersect_epi16` instruction exists in any x86 ISA — UInt16 intersection must convert indices to UInt32 before comparison, halving effective throughput.
 
+### Rank-and-Permute Sparse Dot on Haswell
+
+`nk_sparse_dot_u32f32_haswell` targets AVX2, which has neither `VP2INTERSECT` nor mask-compress, so it intersects a block of 16 A indices against 8 B indices by _rank_: for each A lane it counts how many B indices are strictly smaller (seven `VPCMPGTD` comparisons against sign-biased lanes, split across even/odd accumulators to shorten the dependency chain).
+That count is the position of the candidate match, fed straight to `_mm256_permutevar8x32_epi32` to gather the aligned B index and weight; a `VPCMPEQD` confirms the match and masks both weights to zero on a miss, so the widening `_mm256_fmadd_pd` accumulation cannot be poisoned by NaN or Inf weights.
+Highly imbalanced inputs (`longer > 64 * shorter`) take a galloping path instead, and the unaligned remainder is finished by the scalar merge.
+
 ### VP2INTERSECT on AMD Turin
 
 `nk_sparse_intersect_u32_turin` uses the `VP2INTERSECT` instruction (Zen5), which produces _two_ 16-bit masks in a single operation — one indicating which elements of A matched any element of B, and vice versa.

--- a/include/numkong/sparse/haswell.h
+++ b/include/numkong/sparse/haswell.h
@@ -73,24 +73,6 @@ NK_INTERNAL nk_f64_t nk_sparse_dot_gallop_b_u32f32_haswell_(nk_u32_t const *a, n
     return sum;
 }
 
-NK_INTERNAL nk_f64_t nk_sparse_dot_merge_u32f32_haswell_(nk_u32_t const *a, nk_u32_t const *b,
-                                                         nk_f32_t const *a_weights, nk_f32_t const *b_weights,
-                                                         nk_size_t a_length, nk_size_t b_length, nk_size_t i,
-                                                         nk_size_t j, nk_f64_t sum) {
-    while (i < a_length && j < b_length) {
-        nk_u32_t a_index = a[i];
-        nk_u32_t b_index = b[j];
-        if (a_index == b_index) {
-            sum += (nk_f64_t)a_weights[i] * (nk_f64_t)b_weights[j];
-            ++i;
-            ++j;
-        }
-        else if (a_index < b_index) ++i;
-        else ++j;
-    }
-    return sum;
-}
-
 NK_INTERNAL nk_f64_t nk_sparse_reduce_f64x4x2_haswell_(__m256d accumulator_low_f64x4, __m256d accumulator_high_f64x4) {
     __m256d total_f64x4 = _mm256_add_pd(accumulator_low_f64x4, accumulator_high_f64x4);
     __m128d total_low_f64x2 = _mm256_castpd256_pd128(total_f64x4);
@@ -103,7 +85,6 @@ NK_INTERNAL nk_f64_t nk_sparse_reduce_f64x4x2_haswell_(__m256d accumulator_low_f
 NK_PUBLIC void nk_sparse_dot_u32f32_haswell(nk_u32_t const *a, nk_u32_t const *b, nk_f32_t const *a_weights,
                                             nk_f32_t const *b_weights, nk_size_t a_length, nk_size_t b_length,
                                             nk_f64_t *product) {
-
     if ((a_length << 6) < b_length) {
         *product = nk_sparse_dot_gallop_a_u32f32_haswell_(a, b, a_weights, b_weights, a_length, b_length);
         return;
@@ -233,7 +214,9 @@ NK_PUBLIC void nk_sparse_dot_u32f32_haswell(nk_u32_t const *a, nk_u32_t const *b
     }
 
     nk_f64_t vector_sum = nk_sparse_reduce_f64x4x2_haswell_(accumulator_low_f64x4, accumulator_high_f64x4);
-    *product = nk_sparse_dot_merge_u32f32_haswell_(a, b, a_weights, b_weights, a_length, b_length, i, j, vector_sum);
+    nk_f64_t tail_product = 0;
+    nk_sparse_dot_u32f32_serial(a + i, b + j, a_weights + i, b_weights + j, a_length - i, b_length - j, &tail_product);
+    *product = vector_sum + tail_product;
 }
 
 #if defined(__clang__)

--- a/include/numkong/sparse/haswell.h
+++ b/include/numkong/sparse/haswell.h
@@ -1,0 +1,251 @@
+/**
+ *  @brief SIMD-accelerated Sparse Vector Dot Products for Haswell.
+ *  @file include/numkong/sparse/haswell.h
+ *  @author Matt Stuchlik
+ *  @date May 30, 2026
+ *
+ *  @sa include/numkong/sparse.h
+ */
+#ifndef NK_SPARSE_HASWELL_H
+#define NK_SPARSE_HASWELL_H
+
+#if NK_TARGET_X8664_
+#if NK_TARGET_HASWELL
+
+#include "numkong/types.h"
+#include "numkong/sparse/serial.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((target("avx2,f16c,fma,bmi,bmi2"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
+#pragma GCC target("avx2", "f16c", "fma", "bmi", "bmi2")
+#endif
+
+NK_INTERNAL nk_size_t nk_sparse_lower_bound_gallop_u32_haswell_(nk_u32_t const *indices, nk_size_t length,
+                                                                nk_size_t position, nk_u32_t key) {
+    if (position >= length || indices[position] >= key) return position;
+
+    nk_size_t step = 1;
+    while (position + step < length && indices[position + step] < key) step <<= 1;
+
+    nk_size_t low = position + (step >> 1) + 1;
+    nk_size_t high = position + step + 1;
+    if (high > length) high = length;
+
+    while (low < high) {
+        nk_size_t middle = low + ((high - low) >> 1);
+        if (indices[middle] < key) low = middle + 1;
+        else high = middle;
+    }
+    return low;
+}
+
+NK_INTERNAL nk_f64_t nk_sparse_dot_gallop_a_u32f32_haswell_(nk_u32_t const *a, nk_u32_t const *b,
+                                                            nk_f32_t const *a_weights, nk_f32_t const *b_weights,
+                                                            nk_size_t a_length, nk_size_t b_length) {
+    nk_f64_t sum = 0;
+    nk_size_t j = 0;
+    for (nk_size_t i = 0; i < a_length; ++i) {
+        nk_u32_t a_index = a[i];
+        j = nk_sparse_lower_bound_gallop_u32_haswell_(b, b_length, j, a_index);
+        if (j == b_length) break;
+        if (b[j] == a_index) sum += (nk_f64_t)a_weights[i] * (nk_f64_t)b_weights[j];
+    }
+    return sum;
+}
+
+NK_INTERNAL nk_f64_t nk_sparse_dot_gallop_b_u32f32_haswell_(nk_u32_t const *a, nk_u32_t const *b,
+                                                            nk_f32_t const *a_weights, nk_f32_t const *b_weights,
+                                                            nk_size_t a_length, nk_size_t b_length) {
+    nk_f64_t sum = 0;
+    nk_size_t i = 0;
+    for (nk_size_t j = 0; j < b_length; ++j) {
+        nk_u32_t b_index = b[j];
+        i = nk_sparse_lower_bound_gallop_u32_haswell_(a, a_length, i, b_index);
+        if (i == a_length) break;
+        if (a[i] == b_index) sum += (nk_f64_t)a_weights[i] * (nk_f64_t)b_weights[j];
+    }
+    return sum;
+}
+
+NK_INTERNAL nk_f64_t nk_sparse_dot_merge_u32f32_haswell_(nk_u32_t const *a, nk_u32_t const *b,
+                                                         nk_f32_t const *a_weights, nk_f32_t const *b_weights,
+                                                         nk_size_t a_length, nk_size_t b_length, nk_size_t i,
+                                                         nk_size_t j, nk_f64_t sum) {
+    while (i < a_length && j < b_length) {
+        nk_u32_t a_index = a[i];
+        nk_u32_t b_index = b[j];
+        if (a_index == b_index) {
+            sum += (nk_f64_t)a_weights[i] * (nk_f64_t)b_weights[j];
+            ++i;
+            ++j;
+        }
+        else if (a_index < b_index) ++i;
+        else ++j;
+    }
+    return sum;
+}
+
+NK_INTERNAL nk_f64_t nk_sparse_reduce_f64x4x2_haswell_(__m256d accumulator_low_f64x4, __m256d accumulator_high_f64x4) {
+    __m256d total_f64x4 = _mm256_add_pd(accumulator_low_f64x4, accumulator_high_f64x4);
+    __m128d total_low_f64x2 = _mm256_castpd256_pd128(total_f64x4);
+    __m128d total_high_f64x2 = _mm256_extractf128_pd(total_f64x4, 1);
+    __m128d sum_f64x2 = _mm_add_pd(total_low_f64x2, total_high_f64x2);
+    __m128d sum_f64x1 = _mm_add_sd(sum_f64x2, _mm_unpackhi_pd(sum_f64x2, sum_f64x2));
+    return _mm_cvtsd_f64(sum_f64x1);
+}
+
+NK_PUBLIC void nk_sparse_dot_u32f32_haswell(nk_u32_t const *a, nk_u32_t const *b, nk_f32_t const *a_weights,
+                                            nk_f32_t const *b_weights, nk_size_t a_length, nk_size_t b_length,
+                                            nk_f64_t *product) {
+
+    if ((a_length << 6) < b_length) {
+        *product = nk_sparse_dot_gallop_a_u32f32_haswell_(a, b, a_weights, b_weights, a_length, b_length);
+        return;
+    }
+    if ((b_length << 6) < a_length) {
+        *product = nk_sparse_dot_gallop_b_u32f32_haswell_(a, b, a_weights, b_weights, a_length, b_length);
+        return;
+    }
+
+    nk_size_t i = 0;
+    nk_size_t j = 0;
+    __m256d accumulator_low_f64x4 = _mm256_setzero_pd();
+    __m256d accumulator_high_f64x4 = _mm256_setzero_pd();
+
+    if (a_length >= 16 && b_length >= 8) {
+        nk_size_t a_last_block_start = a_length - 16;
+        nk_size_t b_last_block_start = b_length - 8;
+
+        while (i <= a_last_block_start && j <= b_last_block_start) {
+            // Compare a block of 16 A indices against 8 B indices. Since AVX2 lacks unsigned
+            // i32 comparisons, bias both sides by the sign bit and use signed comparisons below.
+            __m256i a_indices_low_u32x8 = _mm256_loadu_si256((__m256i const *)(a + i));
+            __m256i a_indices_high_u32x8 = _mm256_loadu_si256((__m256i const *)(a + i + 8));
+            __m256i b_indices_u32x8 = _mm256_loadu_si256((__m256i const *)(b + j));
+            __m256 b_weights_f32x8 = _mm256_loadu_ps(b_weights + j);
+            __m256i zero_i32x8 = _mm256_setzero_si256();
+            __m256i sign_bit_u32x8 = _mm256_set1_epi32((int)0x80000000u);
+            __m256i a_indices_low_biased_i32x8 = _mm256_xor_si256(a_indices_low_u32x8, sign_bit_u32x8);
+            __m256i a_indices_high_biased_i32x8 = _mm256_xor_si256(a_indices_high_u32x8, sign_bit_u32x8);
+
+            _mm_prefetch((char const *)(b + j + 512), _MM_HINT_T0);
+            _mm_prefetch((char const *)(a + i + 512), _MM_HINT_T0);
+
+            // Build the rank of each A index within the B block. Ranks are split into even
+            // and odd accumulators to reduce dependency-chain pressure in this hot loop.
+            __m256i b_index_0_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 0] ^ (nk_u32_t)0x80000000u));
+            __m256i rank_low_even_i32x8 = _mm256_sub_epi32(
+                zero_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_0_biased_i32x8));
+            __m256i rank_high_even_i32x8 = _mm256_sub_epi32(
+                zero_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_0_biased_i32x8));
+
+            __m256i b_index_1_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 1] ^ (nk_u32_t)0x80000000u));
+            __m256i rank_low_odd_i32x8 = _mm256_sub_epi32(
+                zero_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_1_biased_i32x8));
+            __m256i rank_high_odd_i32x8 = _mm256_sub_epi32(
+                zero_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_1_biased_i32x8));
+
+            __m256i b_index_2_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 2] ^ (nk_u32_t)0x80000000u));
+            rank_low_even_i32x8 = _mm256_sub_epi32(
+                rank_low_even_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_2_biased_i32x8));
+            rank_high_even_i32x8 = _mm256_sub_epi32(
+                rank_high_even_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_2_biased_i32x8));
+
+            __m256i b_index_3_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 3] ^ (nk_u32_t)0x80000000u));
+            rank_low_odd_i32x8 = _mm256_sub_epi32(
+                rank_low_odd_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_3_biased_i32x8));
+            rank_high_odd_i32x8 = _mm256_sub_epi32(
+                rank_high_odd_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_3_biased_i32x8));
+
+            __m256i b_index_4_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 4] ^ (nk_u32_t)0x80000000u));
+            rank_low_even_i32x8 = _mm256_sub_epi32(
+                rank_low_even_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_4_biased_i32x8));
+            rank_high_even_i32x8 = _mm256_sub_epi32(
+                rank_high_even_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_4_biased_i32x8));
+
+            __m256i b_index_5_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 5] ^ (nk_u32_t)0x80000000u));
+            rank_low_odd_i32x8 = _mm256_sub_epi32(
+                rank_low_odd_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_5_biased_i32x8));
+            rank_high_odd_i32x8 = _mm256_sub_epi32(
+                rank_high_odd_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_5_biased_i32x8));
+
+            __m256i b_index_6_biased_i32x8 = _mm256_set1_epi32((int)(b[j + 6] ^ (nk_u32_t)0x80000000u));
+            rank_low_even_i32x8 = _mm256_sub_epi32(
+                rank_low_even_i32x8, _mm256_cmpgt_epi32(a_indices_low_biased_i32x8, b_index_6_biased_i32x8));
+            rank_high_even_i32x8 = _mm256_sub_epi32(
+                rank_high_even_i32x8, _mm256_cmpgt_epi32(a_indices_high_biased_i32x8, b_index_6_biased_i32x8));
+
+            __m256i rank_low_i32x8 = _mm256_add_epi32(rank_low_even_i32x8, rank_low_odd_i32x8);
+            __m256i rank_high_i32x8 = _mm256_add_epi32(rank_high_even_i32x8, rank_high_odd_i32x8);
+
+            // Use the ranks to align each A lane with its candidate B lane, then mask both
+            // weights so non-matching NaN/Inf values cannot poison the floating-point sum.
+            __m256i b_indices_permuted_high_u32x8 = _mm256_permutevar8x32_epi32(b_indices_u32x8, rank_high_i32x8);
+            __m256i matches_high_b32x8 = _mm256_cmpeq_epi32(b_indices_permuted_high_u32x8, a_indices_high_u32x8);
+            __m256 b_weights_permuted_high_f32x8 = _mm256_permutevar8x32_ps(b_weights_f32x8, rank_high_i32x8);
+            __m256 a_weights_matched_high_f32x8 = _mm256_and_ps(_mm256_castsi256_ps(matches_high_b32x8),
+                                                                _mm256_loadu_ps(a_weights + i + 8));
+            __m256 b_weights_matched_high_f32x8 = _mm256_and_ps(_mm256_castsi256_ps(matches_high_b32x8),
+                                                                b_weights_permuted_high_f32x8);
+
+            __m256i b_indices_permuted_low_u32x8 = _mm256_permutevar8x32_epi32(b_indices_u32x8, rank_low_i32x8);
+            __m256i matches_low_b32x8 = _mm256_cmpeq_epi32(b_indices_permuted_low_u32x8, a_indices_low_u32x8);
+            __m256 b_weights_permuted_low_f32x8 = _mm256_permutevar8x32_ps(b_weights_f32x8, rank_low_i32x8);
+            __m256 a_weights_matched_low_f32x8 = _mm256_and_ps(_mm256_castsi256_ps(matches_low_b32x8),
+                                                               _mm256_loadu_ps(a_weights + i));
+            __m256 b_weights_matched_low_f32x8 = _mm256_and_ps(_mm256_castsi256_ps(matches_low_b32x8),
+                                                               b_weights_permuted_low_f32x8);
+
+            // Widen matched f32 products to f64 before accumulation. The low/high accumulators
+            // refer to the two f64 halves produced by converting each f32x8 vector.
+            accumulator_low_f64x4 = _mm256_fmadd_pd(
+                _mm256_cvtps_pd(_mm256_castps256_ps128(a_weights_matched_low_f32x8)),
+                _mm256_cvtps_pd(_mm256_castps256_ps128(b_weights_matched_low_f32x8)), accumulator_low_f64x4);
+            accumulator_high_f64x4 = _mm256_fmadd_pd(
+                _mm256_cvtps_pd(_mm256_extractf128_ps(a_weights_matched_low_f32x8, 1)),
+                _mm256_cvtps_pd(_mm256_extractf128_ps(b_weights_matched_low_f32x8, 1)), accumulator_high_f64x4);
+            accumulator_low_f64x4 = _mm256_fmadd_pd(
+                _mm256_cvtps_pd(_mm256_castps256_ps128(a_weights_matched_high_f32x8)),
+                _mm256_cvtps_pd(_mm256_castps256_ps128(b_weights_matched_high_f32x8)), accumulator_low_f64x4);
+            accumulator_high_f64x4 = _mm256_fmadd_pd(
+                _mm256_cvtps_pd(_mm256_extractf128_ps(a_weights_matched_high_f32x8, 1)),
+                _mm256_cvtps_pd(_mm256_extractf128_ps(b_weights_matched_high_f32x8, 1)), accumulator_high_f64x4);
+
+            // Advance the side whose current block cannot overlap the other side's current block.
+            // If both can still overlap, advance A by half a block to reuse the same B block.
+            nk_size_t a_position_next = i + 8;
+            nk_u32_t b_index_last = b[j + 7];
+            if (a[i + 7] > b_index_last) a_position_next = i;
+            if (a[i + 15] <= b_index_last) a_position_next = i + 16;
+
+            nk_size_t b_position_next = j + 8;
+            if (a[i + 15] < b_index_last) b_position_next = j;
+
+            i = a_position_next;
+            j = b_position_next;
+        }
+    }
+
+    nk_f64_t vector_sum = nk_sparse_reduce_f64x4x2_haswell_(accumulator_low_f64x4, accumulator_high_f64x4);
+    *product = nk_sparse_dot_merge_u32f32_haswell_(a, b, a_weights, b_weights, a_length, b_length, i, j, vector_sum);
+}
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // NK_TARGET_HASWELL
+#endif // NK_TARGET_X8664_
+#endif // NK_SPARSE_HASWELL_H

--- a/test/test_sparse.cpp
+++ b/test/test_sparse.cpp
@@ -102,6 +102,10 @@ void test_sparse() {
     check("sparse_dot_u32f32_icelake", test_sparse_dot<f32_t>, nk_sparse_dot_u32f32_icelake);
 #endif // NK_TARGET_ICELAKE
 
+#if NK_TARGET_HASWELL
+    check("sparse_dot_u32f32_haswell", test_sparse_dot<f32_t>, nk_sparse_dot_u32f32_haswell);
+#endif // NK_TARGET_HASWELL
+
 #if NK_TARGET_TURIN
     check("sparse_intersect_u16_turin", test_intersect<u16_t>, nk_sparse_intersect_u16_turin);
     check("sparse_intersect_u32_turin", test_intersect<u32_t>, nk_sparse_intersect_u32_turin);


### PR DESCRIPTION
## Overview

Add a Haswell AVX2 backend for `nk_sparse_dot_u32f32`.

The new kernel uses AVX2 ranking/permutation over blocks of 16 A indices and 8 B indices, with scalar merge/gallop fallbacks for tails and very imbalanced sparse vectors. It is wired into static dispatch, runtime dispatch, `nk_test`, and `nk_bench`.

The code is based on a performance challenge we're running on [cpu.mattstuchlik.com], primarily by me and @josusanmartin: (https://cpu.mattstuchlik.com/challenge/numkong_sparse_dot).

## Additional Information

Benchmarked on a Raptor Cove CPU with a Haswell-enabled build:

| kernel | case | mean | median | stddev | throughput |
| --- | --- | ---: | ---: | ---: | ---: |
| `sparse_dot_u32f32_haswell` | `\|A\|=1024, \|B\|=8192, \|A^B\|=512` | 13,789 ns | 13,785 ns | 17.2 ns | 5.347 GB/s |

I also ran the focused precision test with NK_ULP_THRESHOLD_F32=64:

```bash
OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 NK_ULP_THRESHOLD_F32=64 \
  ./build_release_blas/nk_test \
  --filter=sparse_dot_u32f32_haswell \
  --time-budget=100 \
  --assert

sparse_dot_u32f32_haswell  max_abs=7.11e-15  max_rel=7.26e-15  mean_ulp=2.21e-01  max_ulp=64
All tests passed.
```

Notably it fails with the default NK_ULP_THRESHOLD_F32, but then `sparse_dot_u32f32_serial` also fails under those constraints, so I'm assuming it's fine?

Formatting was run with `clang-format` 22.