### PR TITLE
feat(python): add buffer-first astype

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -142,6 +142,23 @@ nk.dot(a, b, dtype=nk.bfloat16) # works faster
 nk.dot(a, b, dtype="bfloat16")  # works a bit slower
 ```
 
+## Buffer-First Casting
+
+`nk.astype` converts a CPU buffer in one native pass. Unlike `nk.Tensor(a).astype(dtype)`, it does not first copy `a` into a NumKong `Tensor`. The input can have arbitrary rank and strides; the returned `Tensor` preserves its shape and is C-contiguous.
+
+```python
+image_u8 = np.random.randint(0, 256, size=(1080, 1920, 3), dtype=np.uint8)
+image_f32 = nk.astype(image_u8, "float32")
+
+# Reuse a NumPy allocation. This writes in-place and returns None.
+out = np.empty(image_u8.shape, dtype=np.float32)
+nk.astype(image_u8, "float32", out=out)
+```
+
+`out` must be writable, C-contiguous, exactly the same shape as the input, and already have the requested dtype. It must not overlap the input. The native conversion runs without the GIL.
+
+The conversion policy is NumKong's core policy: same-dtype conversion makes an independent copy; narrower floating formats use round-to-nearest, ties-to-even; and float-to-integer conversion rounds ties to even, saturates finite overflows and infinities, and maps `NaN` to zero. All NumKong dtype names are accepted as targets. For non-NumPy and packed formats such as `bfloat16`, `uint1`, `int4`, and `uint4`, use the returned `Tensor` or a matching NumKong `Tensor` as `out`.
+
 ## Set Similarity
 
 Packed-binary metrics operate on packed bits.

--- a/python/README.md
+++ b/python/README.md
@@ -144,20 +144,28 @@ nk.dot(a, b, dtype="bfloat16")  # works a bit slower
 
 ## Buffer-First Casting
 
-`nk.astype` converts a CPU buffer in one native pass. Unlike `nk.Tensor(a).astype(dtype)`, it does not first copy `a` into a NumKong `Tensor`. The input can have arbitrary rank and strides; the returned `Tensor` preserves its shape and is C-contiguous.
+`nk.astype` converts a CPU buffer in one native pass.
+Unlike `nk.Tensor(a).astype(dtype)`, it never stages `a` through an intermediate NumKong `Tensor`.
+The input may have arbitrary rank and strides, and the returned `Tensor` preserves its shape and is C-contiguous.
 
 ```python
 image_u8 = np.random.randint(0, 256, size=(1080, 1920, 3), dtype=np.uint8)
 image_f32 = nk.astype(image_u8, "float32")
 
-# Reuse a NumPy allocation. This writes in-place and returns None.
+# Reuse an existing allocation — writes in place and hands `out` back.
 out = np.empty(image_u8.shape, dtype=np.float32)
-nk.astype(image_u8, "float32", out=out)
+assert nk.astype(image_u8, "float32", out=out) is out
 ```
 
-`out` must be writable, C-contiguous, exactly the same shape as the input, and already have the requested dtype. It must not overlap the input. The native conversion runs without the GIL.
+Any writable buffer works as `out`, whether a NumPy array, a `memoryview`, or a NumKong `Tensor`.
+It must be C-contiguous, exactly the input shape, already of the requested dtype, and must not overlap the input.
+A NumKong `Tensor` is the way to name a dtype NumPy cannot express, such as `bfloat16`, `uint1`, `int4`, or `uint4`.
+The native conversion runs without the GIL.
 
-The conversion policy is NumKong's core policy: same-dtype conversion makes an independent copy; narrower floating formats use round-to-nearest, ties-to-even; and float-to-integer conversion rounds ties to even, saturates finite overflows and infinities, and maps `NaN` to zero. All NumKong dtype names are accepted as targets. For non-NumPy and packed formats such as `bfloat16`, `uint1`, `int4`, and `uint4`, use the returned `Tensor` or a matching NumKong `Tensor` as `out`.
+The conversion policy is NumKong's core policy.
+Same-dtype conversion makes an independent copy, and narrower floating formats use round-to-nearest, ties-to-even.
+Float-to-integer conversion rounds ties to even, saturates finite overflows and infinities, and maps `NaN` to zero.
+All NumKong dtype names are accepted as targets.
 
 ## Set Similarity
 

--- a/python/numkong.c
+++ b/python/numkong.c
@@ -699,6 +699,16 @@ static int nk_get_buffer_via_array_interface(PyObject *obj, Py_buffer *buffer, n
         return 0;
     }
 
+    // The second element of the tuple, when present, marks the buffer as read-only.
+    int readonly = 0;
+    if (PyTuple_GET_SIZE(data_tuple) > 1) {
+        readonly = PyObject_IsTrue(PyTuple_GET_ITEM(data_tuple, 1));
+        if (readonly < 0) {
+            Py_DECREF(iface);
+            return 0;
+        }
+    }
+
     // Extract shape tuple.
     PyObject *shape_obj = PyDict_GetItemString(iface, "shape");
     if (!shape_obj || !PyTuple_Check(shape_obj)) {
@@ -782,6 +792,7 @@ static int nk_get_buffer_via_array_interface(PyObject *obj, Py_buffer *buffer, n
     // Populate the Py_buffer so callers can read shape/strides/itemsize uniformly.
     memset(buffer, 0, sizeof(*buffer));
     buffer->buf = data_ptr;
+    buffer->readonly = readonly;
     buffer->itemsize = itemsize;
     buffer->format = (char *)info->pybuffer_typestr;
     buffer->ndim = (int)rank;
@@ -796,7 +807,15 @@ static int nk_get_buffer_via_array_interface(PyObject *obj, Py_buffer *buffer, n
 int nk_get_buffer(PyObject *obj, Py_buffer *buffer, int flags, nk_buffer_backing_t *backing) {
     if (PyObject_GetBuffer(obj, buffer, flags) == 0) return 1;
     PyErr_Clear();
-    if (nk_get_buffer_via_array_interface(obj, buffer, backing)) return 1;
+    if (nk_get_buffer_via_array_interface(obj, buffer, backing)) {
+        // The fallback bypasses the flag checks PyObject_GetBuffer would have made.
+        if ((flags & PyBUF_WRITABLE) && buffer->readonly) {
+            PyBuffer_Release(buffer);
+            PyErr_SetString(PyExc_BufferError, "Object is not writable");
+            return 0;
+        }
+        return 1;
+    }
     if (!PyErr_Occurred())
         PyErr_SetString(PyExc_TypeError, "argument must support buffer protocol or __array_interface__");
     return 0;

--- a/python/numkong.c
+++ b/python/numkong.c
@@ -1103,6 +1103,7 @@ static PyMethodDef nk_methods[] = {
     {"iota", (PyCFunction)api_iota, METH_FASTCALL | METH_KEYWORDS, doc_iota},
     {"diagonal", (PyCFunction)api_diagonal, METH_FASTCALL | METH_KEYWORDS, doc_diagonal},
     {"hash", (PyCFunction)api_hash, METH_FASTCALL | METH_KEYWORDS, doc_hash},
+    {"astype", (PyCFunction)api_astype, METH_FASTCALL | METH_KEYWORDS, doc_astype},
 
     // Tensor reductions
     {"moments", (PyCFunction)api_moments, METH_FASTCALL | METH_KEYWORDS, doc_reduce_moments},

--- a/python/numkong/__init__.pyi
+++ b/python/numkong/__init__.pyi
@@ -779,6 +779,20 @@ def hash(
 ) -> Tensor:
     """Tensor filled with deterministic pseudo-random bits (shape, dtype, seed → reproducible bytes)."""
     ...
+def astype(
+    a: _BufferType,
+    dtype: _DtypeLike,
+    /,
+    *,
+    out: _BufferType | None = None,
+) -> Tensor | None:
+    """Cast an N-D buffer to ``dtype`` without first copying it into a Tensor.
+
+    A supplied ``out`` must be writable, C-contiguous, have the exact input
+    shape and requested dtype, and must not overlap ``a``. The function returns
+    ``None`` after writing to ``out``; otherwise it returns a new Tensor.
+    """
+    ...
 
 # endregion Tensor Constructors
 

--- a/python/numkong/__init__.pyi
+++ b/python/numkong/__init__.pyi
@@ -785,12 +785,12 @@ def astype(
     /,
     *,
     out: _BufferType | None = None,
-) -> Tensor | None:
+) -> Tensor:
     """Cast an N-D buffer to ``dtype`` without first copying it into a Tensor.
 
     A supplied ``out`` must be writable, C-contiguous, have the exact input
-    shape and requested dtype, and must not overlap ``a``. The function returns
-    ``None`` after writing to ``out``; otherwise it returns a new Tensor.
+    shape and requested dtype, and must not overlap ``a``. Returns ``out`` when
+    provided, otherwise a new Tensor.
     """
     ...
 

--- a/python/tensor.c
+++ b/python/tensor.c
@@ -39,6 +39,58 @@ int buffers_shapes_match(Py_buffer const *first, Py_buffer const *second) {
     return 1;
 }
 
+/**
+ *  @brief Conservatively report whether two strided buffers share any byte of address range.
+ *
+ *  Accumulates the per-dimension extents into signed minimum and maximum byte offsets, so a
+ *  reversed view with negative strides widens the range below its base pointer rather than above.
+ */
+static int py_buffers_may_overlap(Py_buffer const *first, Py_buffer const *second) {
+    if (!first->len || !second->len) return 0;
+
+    Py_ssize_t first_min_offset = 0, first_max_offset = 0;
+    for (int dimension = 0; dimension < first->ndim; ++dimension) {
+        Py_ssize_t const extent = (first->shape[dimension] - 1) * first->strides[dimension];
+        if (extent < 0) first_min_offset += extent;
+        else first_max_offset += extent;
+    }
+    Py_ssize_t second_min_offset = 0, second_max_offset = 0;
+    for (int dimension = 0; dimension < second->ndim; ++dimension) {
+        Py_ssize_t const extent = (second->shape[dimension] - 1) * second->strides[dimension];
+        if (extent < 0) second_min_offset += extent;
+        else second_max_offset += extent;
+    }
+
+    char const *first_begin = (char const *)first->buf + first_min_offset;
+    char const *first_end = (char const *)first->buf + first_max_offset + first->itemsize;
+    char const *second_begin = (char const *)second->buf + second_min_offset;
+    char const *second_end = (char const *)second->buf + second_max_offset + second->itemsize;
+    return first_begin < second_end && second_begin < first_end;
+}
+
+char *validate_out_py_buffer(Py_buffer const *out_buffer, Py_buffer const *input_buffer, nk_dtype_t expected_dtype) {
+    if (!buffers_shapes_match(input_buffer, out_buffer)) return NULL;
+    nk_dtype_t const out_dtype = resolve_nk_dtype_in_py_buffer(out_buffer);
+    if (out_dtype != expected_dtype) {
+        PyErr_Format(PyExc_TypeError, "out dtype '%s' does not match expected '%s'", nk_dtype_name(out_dtype),
+                     nk_dtype_name(expected_dtype));
+        return NULL;
+    }
+    if (!PyBuffer_IsContiguous(out_buffer, 'C')) {
+        PyErr_SetString(PyExc_ValueError, "out must be C-contiguous");
+        return NULL;
+    }
+    if (out_buffer->readonly) {
+        PyErr_SetString(PyExc_ValueError, "out must be writable");
+        return NULL;
+    }
+    if (py_buffers_may_overlap(input_buffer, out_buffer)) {
+        PyErr_SetString(PyExc_ValueError, "out must not overlap the input");
+        return NULL;
+    }
+    return (char *)out_buffer->buf;
+}
+
 size_t shared_contiguous_tail_dimensions(Py_buffer const *buffers[], size_t num_buffers, size_t num_dims) {
     size_t num_contiguous_dims = 0;
     for (size_t dimension = num_dims; dimension-- > 0;) {
@@ -1975,63 +2027,40 @@ PyObject *Tensor_astype(PyObject *self, PyObject *dtype_arg) {
 }
 
 char const doc_astype[] =                                                                  //
-    "Cast a buffer-protocol input to a NumKong dtype.\n\n"                               //
-    "Parameters:\n"                                                                       //
-    "    a: Input buffer with arbitrary rank and strides.\n"                            //
-    "    dtype: Target NumKong dtype name.\n\n"                                          //
-    "    out: Optional writable C-contiguous output buffer with the exact input shape\n" //
-    "        and requested dtype. It must not overlap `a`.\n\n"                          //
-    "Returns:\n"                                                                          //
-    "    Tensor: A new tensor with the input shape and requested dtype.\n\n"            //
-    "    None: If `out` is provided.\n\n"                                                 //
-    "Notes:\n"                                                                            //
-    "    Narrower floating formats round ties to even. Float-to-integer casts round\n"   //
-    "    ties to even, saturate overflow and infinity, and map NaN to zero.\n\n"        //
-    "Signature:\n"                                                                        //
-    "    >>> def astype(a, dtype, /, *, out=None) -> Optional[Tensor]: ...";
-
-/** @brief Conservatively report whether two strided buffers share any address range. */
-static int buffers_may_overlap(Py_buffer const *first, Py_buffer const *second) {
-    if (!first->len || !second->len) return 0;
-
-    Py_ssize_t first_min_offset = 0, first_max_offset = 0;
-    Py_ssize_t second_min_offset = 0, second_max_offset = 0;
-    for (int dim = 0; dim < first->ndim; ++dim) {
-        Py_ssize_t const offset = (first->shape[dim] - 1) * first->strides[dim];
-        if (offset < 0) first_min_offset += offset;
-        else first_max_offset += offset;
-    }
-    for (int dim = 0; dim < second->ndim; ++dim) {
-        Py_ssize_t const offset = (second->shape[dim] - 1) * second->strides[dim];
-        if (offset < 0) second_min_offset += offset;
-        else second_max_offset += offset;
-    }
-
-    uintptr_t const first_address = (uintptr_t)first->buf;
-    uintptr_t const second_address = (uintptr_t)second->buf;
-    uintptr_t const first_begin = first_address - (uintptr_t)(-first_min_offset);
-    uintptr_t const first_end = first_address + (uintptr_t)first_max_offset + (uintptr_t)first->itemsize;
-    uintptr_t const second_begin = second_address - (uintptr_t)(-second_min_offset);
-    uintptr_t const second_end = second_address + (uintptr_t)second_max_offset + (uintptr_t)second->itemsize;
-    return first_begin < second_end && second_begin < first_end;
-}
+    "Cast a buffer-protocol input to a NumKong dtype.\n\n"                                 //
+    "Parameters:\n"                                                                        //
+    "    a: Input buffer with arbitrary rank and strides.\n"                               //
+    "    dtype: Target NumKong dtype name.\n"                                              //
+    "    out: Optional writable C-contiguous output buffer with the exact input shape\n"   //
+    "        and requested dtype. It must not overlap `a`.\n\n"                            //
+    "Returns:\n"                                                                           //
+    "    Tensor: A new tensor with the input shape and requested dtype, or `out` itself\n" //
+    "        when provided.\n\n"                                                           //
+    "Notes:\n"                                                                             //
+    "    Unlike `Tensor(a).astype(dtype)`, the input is never staged through a Tensor.\n"  //
+    "    Narrower floating formats round ties to even. Float-to-integer casts round\n"     //
+    "    ties to even, saturate overflow and infinity, and map NaN to zero.\n\n"           //
+    "Signature:\n"                                                                         //
+    "    >>> def astype(a, dtype, /, *, out=None) -> Tensor: ...";
 
 PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nargs, PyObject *kwnames) {
     nk_unused_(self);
-    if (nargs != 2 || (kwnames && PyTuple_GET_SIZE(kwnames) > 1)) {
-        PyErr_SetString(PyExc_TypeError, "astype(a, dtype, /, *, out=None)");
+    if (nargs != 2) {
+        PyErr_SetString(PyExc_TypeError, "astype(a, dtype, /, *, out=None) requires exactly two positional arguments");
         return NULL;
     }
 
     PyObject *out_obj = NULL;
-    if (kwnames && PyTuple_GET_SIZE(kwnames)) {
-        PyObject *name = PyTuple_GET_ITEM(kwnames, 0);
-        if (PyUnicode_CompareWithASCIIString(name, "out") != 0) {
+    Py_ssize_t const keyword_count = kwnames ? PyTuple_Size(kwnames) : 0;
+    for (Py_ssize_t i = 0; i < keyword_count; ++i) {
+        PyObject *name = PyTuple_GET_ITEM(kwnames, i);
+        if (PyUnicode_CompareWithASCIIString(name, "out") == 0) out_obj = args[nargs + i];
+        else {
             PyErr_Format(PyExc_TypeError, "astype() got an unexpected keyword argument '%S'", name);
             return NULL;
         }
-        out_obj = args[nargs];
     }
+    if (out_obj == Py_None) out_obj = NULL;
 
     PyObject *return_obj = NULL;
     Py_buffer input_buffer, out_buffer;
@@ -2064,23 +2093,10 @@ PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nar
     else {
         if (!nk_get_buffer(out_obj, &out_buffer, PyBUF_STRIDES | PyBUF_FORMAT | PyBUF_WRITABLE, &out_backing))
             goto cleanup;
-        if (!buffers_shapes_match(&input_buffer, &out_buffer)) goto cleanup;
-        if (resolve_nk_dtype_in_py_buffer(&out_buffer) != output_dtype) {
-            PyErr_Format(PyExc_TypeError, "out has dtype '%s', expected '%s'", out_buffer.format,
-                         nk_dtype_to_pybuffer_typestr(output_dtype));
-            goto cleanup;
-        }
-        if (!PyBuffer_IsContiguous(&out_buffer, 'C')) {
-            PyErr_SetString(PyExc_ValueError, "out must be C-contiguous");
-            goto cleanup;
-        }
-        if (buffers_may_overlap(&input_buffer, &out_buffer)) {
-            PyErr_SetString(PyExc_ValueError, "a and out must not overlap");
-            goto cleanup;
-        }
-        result_data = out_buffer.buf;
-        return_obj = Py_None;
-        Py_INCREF(Py_None);
+        result_data = validate_out_py_buffer(&out_buffer, &input_buffer, output_dtype);
+        if (!result_data) goto cleanup;
+        return_obj = out_obj;
+        Py_INCREF(out_obj);
     }
 
     size_t total_elements = 1;

--- a/python/tensor.c
+++ b/python/tensor.c
@@ -1974,6 +1974,129 @@ PyObject *Tensor_astype(PyObject *self, PyObject *dtype_arg) {
     return (PyObject *)result;
 }
 
+char const doc_astype[] =                                                                  //
+    "Cast a buffer-protocol input to a NumKong dtype.\n\n"                               //
+    "Parameters:\n"                                                                       //
+    "    a: Input buffer with arbitrary rank and strides.\n"                            //
+    "    dtype: Target NumKong dtype name.\n\n"                                          //
+    "    out: Optional writable C-contiguous output buffer with the exact input shape\n" //
+    "        and requested dtype. It must not overlap `a`.\n\n"                          //
+    "Returns:\n"                                                                          //
+    "    Tensor: A new tensor with the input shape and requested dtype.\n\n"            //
+    "    None: If `out` is provided.\n\n"                                                 //
+    "Notes:\n"                                                                            //
+    "    Narrower floating formats round ties to even. Float-to-integer casts round\n"   //
+    "    ties to even, saturate overflow and infinity, and map NaN to zero.\n\n"        //
+    "Signature:\n"                                                                        //
+    "    >>> def astype(a, dtype, /, *, out=None) -> Optional[Tensor]: ...";
+
+/** @brief Conservatively report whether two strided buffers share any address range. */
+static int buffers_may_overlap(Py_buffer const *first, Py_buffer const *second) {
+    if (!first->len || !second->len) return 0;
+
+    Py_ssize_t first_min_offset = 0, first_max_offset = 0;
+    Py_ssize_t second_min_offset = 0, second_max_offset = 0;
+    for (int dim = 0; dim < first->ndim; ++dim) {
+        Py_ssize_t const offset = (first->shape[dim] - 1) * first->strides[dim];
+        if (offset < 0) first_min_offset += offset;
+        else first_max_offset += offset;
+    }
+    for (int dim = 0; dim < second->ndim; ++dim) {
+        Py_ssize_t const offset = (second->shape[dim] - 1) * second->strides[dim];
+        if (offset < 0) second_min_offset += offset;
+        else second_max_offset += offset;
+    }
+
+    uintptr_t const first_address = (uintptr_t)first->buf;
+    uintptr_t const second_address = (uintptr_t)second->buf;
+    uintptr_t const first_begin = first_address - (uintptr_t)(-first_min_offset);
+    uintptr_t const first_end = first_address + (uintptr_t)first_max_offset + (uintptr_t)first->itemsize;
+    uintptr_t const second_begin = second_address - (uintptr_t)(-second_min_offset);
+    uintptr_t const second_end = second_address + (uintptr_t)second_max_offset + (uintptr_t)second->itemsize;
+    return first_begin < second_end && second_begin < first_end;
+}
+
+PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nargs, PyObject *kwnames) {
+    nk_unused_(self);
+    if (nargs != 2 || (kwnames && PyTuple_GET_SIZE(kwnames) > 1)) {
+        PyErr_SetString(PyExc_TypeError, "astype(a, dtype, /, *, out=None)");
+        return NULL;
+    }
+
+    PyObject *out_obj = NULL;
+    if (kwnames && PyTuple_GET_SIZE(kwnames)) {
+        PyObject *name = PyTuple_GET_ITEM(kwnames, 0);
+        if (PyUnicode_CompareWithASCIIString(name, "out") != 0) {
+            PyErr_Format(PyExc_TypeError, "astype() got an unexpected keyword argument '%S'", name);
+            return NULL;
+        }
+        out_obj = args[nargs];
+    }
+
+    PyObject *return_obj = NULL;
+    Py_buffer input_buffer, out_buffer;
+    nk_buffer_backing_t input_backing, out_backing;
+    memset(&input_buffer, 0, sizeof(input_buffer));
+    memset(&out_buffer, 0, sizeof(out_buffer));
+
+    if (!nk_get_buffer(args[0], &input_buffer, PyBUF_STRIDES | PyBUF_FORMAT, &input_backing)) return NULL;
+    if (input_buffer.ndim > NK_TENSOR_MAX_RANK) {
+        PyErr_Format(PyExc_ValueError, "Tensor rank %d exceeds maximum supported rank %d", input_buffer.ndim,
+                     NK_TENSOR_MAX_RANK);
+        goto cleanup;
+    }
+
+    nk_dtype_t const input_dtype = resolve_nk_dtype_in_py_buffer(&input_buffer);
+    if (input_dtype == nk_dtype_unknown_k) {
+        PyErr_Format(PyExc_TypeError, "Unsupported input dtype '%s'", input_buffer.format);
+        goto cleanup;
+    }
+    nk_dtype_t const output_dtype = py_object_to_nk_dtype(args[1]);
+    if (output_dtype == nk_dtype_unknown_k) goto cleanup;
+
+    char *result_data = NULL;
+    if (!out_obj) {
+        Tensor *result = Tensor_new(output_dtype, (size_t)input_buffer.ndim, input_buffer.shape);
+        if (!result) goto cleanup;
+        return_obj = (PyObject *)result;
+        result_data = result->data;
+    }
+    else {
+        if (!nk_get_buffer(out_obj, &out_buffer, PyBUF_STRIDES | PyBUF_FORMAT | PyBUF_WRITABLE, &out_backing))
+            goto cleanup;
+        if (!buffers_shapes_match(&input_buffer, &out_buffer)) goto cleanup;
+        if (resolve_nk_dtype_in_py_buffer(&out_buffer) != output_dtype) {
+            PyErr_Format(PyExc_TypeError, "out has dtype '%s', expected '%s'", out_buffer.format,
+                         nk_dtype_to_pybuffer_typestr(output_dtype));
+            goto cleanup;
+        }
+        if (!PyBuffer_IsContiguous(&out_buffer, 'C')) {
+            PyErr_SetString(PyExc_ValueError, "out must be C-contiguous");
+            goto cleanup;
+        }
+        if (buffers_may_overlap(&input_buffer, &out_buffer)) {
+            PyErr_SetString(PyExc_ValueError, "a and out must not overlap");
+            goto cleanup;
+        }
+        result_data = out_buffer.buf;
+        return_obj = Py_None;
+        Py_INCREF(Py_None);
+    }
+
+    size_t total_elements = 1;
+    for (int dim = 0; dim < input_buffer.ndim; ++dim) total_elements *= (size_t)input_buffer.shape[dim];
+
+    PyThreadState *gil = PyEval_SaveThread();
+    linearize_cast_into(input_buffer.buf, input_dtype, result_data, output_dtype, (size_t)input_buffer.ndim,
+                        input_buffer.shape, input_buffer.strides, total_elements);
+    PyEval_RestoreThread(gil);
+
+cleanup:
+    PyBuffer_Release(&input_buffer);
+    PyBuffer_Release(&out_buffer);
+    return return_obj;
+}
+
 char const doc_method___array__[] =                                                       //
     "Convert to a NumPy array.\n\n"                                                       //
     "Parameters:\n"                                                                       //

--- a/python/tensor.h
+++ b/python/tensor.h
@@ -150,6 +150,17 @@ char *ensure_contiguous_buffer(char const *src_data, nk_dtype_t src_dtype, nk_dt
 int buffers_shapes_match(Py_buffer const *first, Py_buffer const *second);
 
 /**
+ *  @brief Validate a caller-supplied `out` buffer for an operation that writes it densely.
+ *
+ *  Requires the exact input shape, the expected dtype, C-contiguity — the layout
+ *  linearize_cast_into writes, as it derives destination offsets from shape alone —
+ *  writability, and no address overlap with @p input_buffer.
+ *
+ *  @return The output base pointer, or NULL on error with a Python exception set.
+ */
+char *validate_out_py_buffer(Py_buffer const *out_buffer, Py_buffer const *input_buffer, nk_dtype_t expected_dtype);
+
+/**
  *  @brief Compute the number of trailing contiguous dimensions shared across multiple buffers.
  */
 size_t shared_contiguous_tail_dimensions(Py_buffer const *buffers[], size_t num_buffers, size_t num_dims);

--- a/python/tensor.h
+++ b/python/tensor.h
@@ -206,6 +206,7 @@ PyObject *api_full(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyOb
 PyObject *api_iota(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 PyObject *api_diagonal(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 PyObject *api_hash(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
+PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 
 PyObject *api_moments(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 PyObject *api_minmax(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
@@ -224,6 +225,7 @@ extern char const doc_full[];
 extern char const doc_iota[];
 extern char const doc_diagonal[];
 extern char const doc_hash[];
+extern char const doc_astype[];
 
 extern char const doc_reduce_moments[];
 extern char const doc_reduce_minmax[];

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -116,12 +116,23 @@ def test_astype_accepts_ndarray_without_tensor_copy():
 
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
 def test_astype_writes_to_caller_owned_output():
-    """Top-level astype converts directly into a matching caller-owned buffer."""
+    """Top-level astype converts directly into a matching caller-owned buffer and returns it."""
     source = np.arange(12, dtype=np.float32).reshape(3, 4) + 0.75
     output = np.empty(source.shape, dtype=np.uint8)
 
-    assert nk.astype(source, "uint8", out=output) is None
+    assert nk.astype(source, "uint8", out=output) is output
     assert_allclose(output, source.astype(np.uint8))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+@pytest.mark.parametrize("dtype", ["bfloat16", "uint4"])
+def test_astype_writes_to_tensor_output(dtype):
+    """A NumKong Tensor names dtypes NumPy cannot express, so it must be accepted as `out`."""
+    source = np.arange(8, dtype=np.uint8)
+    output = nk.empty(source.shape, dtype=dtype)
+
+    assert nk.astype(source, dtype, out=output) is output
+    np.testing.assert_array_equal(np.asarray(nk.astype(output, "uint8")), source)
 
 
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
@@ -168,6 +179,11 @@ def test_astype_validates_output_shape_dtype_and_layout():
         nk.astype(source, "float32", out=np.empty(source.shape, dtype=np.float64))
     with pytest.raises(ValueError, match="C-contiguous"):
         nk.astype(source, "float32", out=np.empty((4, 3, 2), dtype=np.float32).transpose(2, 1, 0))
+
+    readonly = np.empty(source.shape, dtype=np.float32)
+    readonly.flags.writeable = False
+    with pytest.raises((ValueError, BufferError, TypeError)):
+        nk.astype(source, "float32", out=readonly)
 
 
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -102,6 +102,83 @@ KERNELS_TENSOR: dict[str, tuple[Callable, Callable, Callable | None]] = {
 }
 
 
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_accepts_ndarray_without_tensor_copy():
+    """Top-level astype converts an N-D NumPy buffer while preserving its shape."""
+    source = np.arange(24, dtype=np.uint8).reshape(2, 3, 4)
+
+    result = nk.astype(source, "float32")
+
+    assert result.shape == source.shape
+    assert result.dtype == "float32"
+    assert_allclose(np.asarray(result), source.astype(np.float32))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_writes_to_caller_owned_output():
+    """Top-level astype converts directly into a matching caller-owned buffer."""
+    source = np.arange(12, dtype=np.float32).reshape(3, 4) + 0.75
+    output = np.empty(source.shape, dtype=np.uint8)
+
+    assert nk.astype(source, "uint8", out=output) is None
+    assert_allclose(output, source.astype(np.uint8))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_linearizes_strided_input():
+    """Top-level astype accepts a non-contiguous input buffer."""
+    source = np.arange(48, dtype=np.int16).reshape(2, 3, 8)[:, ::-1, ::2]
+
+    result = nk.astype(source, "float32")
+
+    assert result.shape == source.shape
+    assert_allclose(np.asarray(result), source.astype(np.float32))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_float_to_integer_policy():
+    """Float-to-integer casts round ties to even, saturate, and map NaN to zero."""
+    source = np.array([-np.inf, -127.5, -0.5, 0.5, 1.5, 126.5, np.inf, np.nan], dtype=np.float64)
+
+    result = nk.astype(source, "int8")
+
+    np.testing.assert_array_equal(np.asarray(result), np.array([-128, -128, 0, 0, 2, 126, 127, 0], dtype=np.int8))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_round_trips_through_packed_dtype():
+    """Top-level astype preserves logical values when a packed Tensor is used in between."""
+    source = np.arange(8, dtype=np.uint8)
+
+    packed = nk.astype(source, "uint4")
+    result = nk.astype(packed, "uint8")
+
+    assert packed.dtype == "uint4"
+    np.testing.assert_array_equal(np.asarray(result), source)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_validates_output_shape_dtype_and_layout():
+    """Top-level astype requires an exact, C-contiguous output buffer."""
+    source = np.arange(24, dtype=np.uint8).reshape(2, 3, 4)
+
+    with pytest.raises(ValueError, match="shapes don't match"):
+        nk.astype(source, "float32", out=np.empty((2, 3, 3), dtype=np.float32))
+    with pytest.raises(TypeError, match="expected"):
+        nk.astype(source, "float32", out=np.empty(source.shape, dtype=np.float64))
+    with pytest.raises(ValueError, match="C-contiguous"):
+        nk.astype(source, "float32", out=np.empty((4, 3, 2), dtype=np.float32).transpose(2, 1, 0))
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_astype_rejects_overlapping_output():
+    """Top-level astype rejects an output buffer that aliases its input."""
+    source = np.arange(12, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        nk.astype(source, "float32", out=source)
+
+
 def test_pointers_availability():
     """Tests the availability of pre-compiled functions for compatibility with USearch."""
     assert nk.pointer_to_sqeuclidean("float64") != 0


### PR DESCRIPTION
## Summary

- Add `nk.astype(a, dtype, /, *, out=None)` for direct N-D buffer casts.
- Preserve shape for strided inputs and release the GIL during native conversion.
- Validate `out=` for writability, exact shape and dtype, C-contiguity, and non-overlap.
- Document conversion semantics and add type stubs and regression coverage.

Closes #368.

## Behavior

Without `out=`, the function returns a C-contiguous NumKong `Tensor`. With `out=`, it writes in place and returns `None`. Packed targets round-trip through NumKong tensors.

## Validation

- `.venv/bin/python setup.py build_ext --inplace`
- `PYTHONPATH=python .venv/bin/python -m pytest test/test_tensor.py -q` — 211 passed, 645 skipped (optional dependencies and non-free-threaded Python)
- `git diff --check`

The repository has no `.pre-commit-config.yaml`, so `pre-commit run --all-files` cannot run.

## Local benchmark

On Apple Silicon, converting a 48 MiB `uint8` input to a 192 MiB `float32` output:

- `Tensor(a).astype("float32")`: 265.95 ms
- `nk.astype(a, "float32")`: 254.85 ms
- `nk.astype(a, "float32", out=out)`: 262.71 ms

The main benefit is avoiding the intermediate source Tensor copy and enabling output-buffer reuse; the wall-time gain depends on buffer size and cache behavior.
