### PR TITLE
feat(python): support N-D nk.scale

### DIFF
--- a/python/each.c
+++ b/python/each.c
@@ -365,13 +365,13 @@ cleanup:
 }
 
 char const doc_scale[] =                                                                               //
-    "Element-wise affine transformation of a single vector.\n\n"                                       //
+    "Element-wise affine transformation of a tensor.\n\n"                                             //
     "Parameters:\n"                                                                                    //
-    "    a (Tensor): Input vector.\n"                                                                  //
+    "    a (Tensor): Input tensor.\n"                                                                  //
     "    dtype (Union[IntegralType, FloatType], optional): Override the presumed numeric type name.\n" //
     "    alpha (float, optional): Multiplicative scale, 1.0 by default.\n"                             //
     "    beta (float, optional): Additive offset, 0.0 by default.\n"                                   //
-    "    out (Tensor, optional): Vector for resulting output.\n\n"                                     //
+    "    out (Tensor, optional): C-contiguous tensor with matching shape and dtype; may be `a`.\n\n"    //
     "Returns:\n"                                                                                       //
     "    Tensor: The result if `out` is not provided.\n"                                               //
     "    None: If `out` is provided. Operation will be performed in-place.\n\n"                        //
@@ -396,7 +396,7 @@ PyObject *api_scale(PyObject *self, PyObject *const *args, Py_ssize_t const posi
     nk_dtype_t dtype = nk_dtype_unknown_k;
 
     Py_buffer a_buffer, out_buffer;
-    MatrixOrVectorView a_parsed, out_parsed;
+    TensorView a_parsed;
     memset(&a_buffer, 0, sizeof(Py_buffer));
     memset(&out_buffer, 0, sizeof(Py_buffer));
 
@@ -438,28 +438,31 @@ PyObject *api_scale(PyObject *self, PyObject *const *args, Py_ssize_t const posi
         if (dtype == nk_dtype_unknown_k) return NULL;
     }
 
-    // Convert `a_obj` to `a_buffer` and to `a_parsed`.
+    // Convert the input into an N-D view and acquire a writable output buffer when supplied.
     nk_buffer_backing_t a_parsed_backing, out_parsed_backing;
-    if (!parse_tensor(a_obj, &a_buffer, &a_parsed, &a_parsed_backing, dtype)) goto cleanup;
-    if (out_obj && !parse_tensor(out_obj, &out_buffer, &out_parsed, &out_parsed_backing, nk_dtype_unknown_k))
+    if (!parse_tensor_nd(a_obj, &a_buffer, &a_parsed, &a_parsed_backing, dtype)) goto cleanup;
+    if (out_obj &&
+        !nk_get_buffer(out_obj, &out_buffer, PyBUF_STRIDES | PyBUF_FORMAT | PyBUF_WRITABLE, &out_parsed_backing))
         goto cleanup;
 
-    // Check dimensions
-    if (a_parsed.rank != 1 || (out_obj && out_parsed.rank != 1)) {
-        PyErr_SetString(PyExc_ValueError, "All tensors must be vectors");
-        goto cleanup;
-    }
-    if (out_obj && a_parsed.cols != out_parsed.cols) {
-        PyErr_SetString(PyExc_ValueError, "Vector dimensions don't match");
+    if (out_obj && !buffers_shapes_match(&a_buffer, &out_buffer)) goto cleanup;
+    if (out_obj && !PyBuffer_IsContiguous(&out_buffer, 'C')) {
+        PyErr_SetString(PyExc_ValueError, "out must be C-contiguous");
         goto cleanup;
     }
 
     // Check data types
-    if (a_parsed.dtype == nk_dtype_unknown_k || (out_obj && out_parsed.dtype == nk_dtype_unknown_k)) {
+    if (a_parsed.dtype == nk_dtype_unknown_k) {
         PyErr_SetString(PyExc_TypeError, "Input tensors must have known dtypes, check with `X.__array_interface__`");
         goto cleanup;
     }
     if (dtype == nk_dtype_unknown_k) dtype = a_parsed.dtype;
+    nk_dtype_t const out_dtype = out_obj ? resolve_nk_dtype_in_py_buffer(&out_buffer) : nk_dtype_unknown_k;
+    if (out_obj && out_dtype != dtype) {
+        PyErr_Format(PyExc_TypeError, "out dtype '%s' does not match input dtype '%s'", \
+                     nk_dtype_name(out_dtype), nk_dtype_name(dtype));
+        goto cleanup;
+    }
 
     // Convert `alpha_obj` to `alpha_buf` and `beta_obj` to `beta_buf`
     nk_scalar_buffer_t alpha_buf, beta_buf;
@@ -492,25 +495,33 @@ PyObject *api_scale(PyObject *self, PyObject *const *args, Py_ssize_t const posi
     }
 
     char *result_data = NULL;
+    Py_ssize_t result_strides[NK_TENSOR_MAX_RANK];
+    Py_buffer const *input_buffers[] = {&a_buffer};
+    size_t contiguous_tail = shared_contiguous_tail_dimensions(input_buffers, 1, a_parsed.rank);
 
     // nk.scale(a, alpha=2.0, beta=1.0) → returns new Tensor with α·a + β
     if (!out_obj) {
-        Py_ssize_t out_shape[1] = {a_parsed.cols};
-        Tensor *result_tensor = Tensor_new(dtype, 1, out_shape);
+        Tensor *result_tensor = Tensor_new(dtype, a_parsed.rank, a_parsed.shape);
         if (!result_tensor) goto cleanup;
         return_obj = (PyObject *)result_tensor;
         result_data = result_tensor->data;
+        compute_contiguous_strides(a_parsed.rank, a_parsed.shape, nk_dtype_bytes_per_value(dtype), result_strides);
     }
     // nk.scale(a, alpha=2.0, out=result) → writes into provided buffer, returns None
     else {
-        result_data = out_parsed.data;
+        result_data = out_buffer.buf;
+        for (size_t dimension = 0; dimension < a_parsed.rank; ++dimension)
+            result_strides[dimension] = out_buffer.strides[dimension];
+        Py_buffer const *both_buffers[] = {&a_buffer, &out_buffer};
+        contiguous_tail = shared_contiguous_tail_dimensions(both_buffers, 2, a_parsed.rank);
         return_obj = Py_None;
         Py_INCREF(Py_None);
     }
 
     {
         PyThreadState *gil = PyEval_SaveThread();
-        kernel(a_parsed.data, a_parsed.cols, &alpha_buf, &beta_buf, result_data);
+        each_scale_recursive(kernel, a_parsed.data, result_data, &alpha_buf, &beta_buf, a_parsed.shape,
+                             a_parsed.strides, result_strides, a_parsed.rank, contiguous_tail);
         PyEval_RestoreThread(gil);
     }
 cleanup:

--- a/test/test_each.py
+++ b/test/test_each.py
@@ -606,6 +606,51 @@ def test_scale_edge_cases(ndim: int, dtype: str, capability: str):
 
 
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_scale_preserves_hwc_shape():
+    """scale accepts an HWC buffer directly and preserves its shape."""
+    image = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+
+    result = nk.scale(image, alpha=0.5, beta=-1.0)
+
+    assert np.asarray(result).shape == image.shape
+    assert_allclose(np.asarray(result), image * 0.5 - 1.0)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+@pytest.mark.parametrize("shape", [(2, 3, 4), (2, 3, 4, 5)])
+def test_scale_writes_nd_output(shape: tuple[int, ...]):
+    """scale writes HWC and NHWC buffers through out= without flattening."""
+    image = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    out = np.empty_like(image)
+
+    assert nk.scale(image, alpha=-0.25, beta=3.0, out=out) is None
+
+    assert_allclose(out, image * -0.25 + 3.0)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_scale_allows_in_place_hwc_output():
+    """scale permits the input HWC buffer as its own output."""
+    image = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    expected = image * 0.5 - 1.0
+
+    assert nk.scale(image, alpha=0.5, beta=-1.0, out=image) is None
+
+    assert_allclose(image, expected)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
+def test_scale_handles_strided_hwc_input():
+    """scale reads an HWC view without materializing a flattened copy."""
+    image = np.arange(4 * 6 * 4, dtype=np.float32).reshape(4, 6, 4)[::2, 1::2]
+    out = np.empty_like(image)
+
+    assert nk.scale(image, alpha=0.5, beta=-1.0, out=out) is None
+
+    assert_allclose(out, image * 0.5 - 1.0)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
 @pytest.mark.repeat(randomized_repetitions_count)
 @pytest.mark.parametrize("ndim", dense_dimensions)
 @pytest.mark.parametrize("dtype", ["float64", "float32", "float16"])


### PR DESCRIPTION
## Summary

- Allow `nk.scale` to accept shape-preserving N-D buffers through the existing stride walker.
- Cover direct HWC and NHWC calls, `out=`, in-place `out=input`, and strided HWC inputs.
- Keep `out=` C-contiguous and same-dtype, consistent with the existing vector contract.

## Why

Callers can now scale images and batches directly, without flattening an input buffer and reshaping the result in Python. This is an API and readability improvement; it intentionally preserves the existing native kernel and has no performance claim.

## Benchmark

Apple arm64, NumKong 7.8.0, NumPy 2.4.4, median of 151 interleaved samples:

| Layout | Shape | Mode | Direct N-D | Flattened vector | Ratio |
| --- | --- | --- | ---: | ---: | ---: |
| HWC | `(1080, 1920, 3)` | Allocate | 3.0835 ms | 3.0875 ms | 0.999x |
| HWC | `(1080, 1920, 3)` | `out=` | 1.5992 ms | 1.6027 ms | 0.998x |
| NHWC | `(4, 512, 512, 3)` | Allocate | 1.4510 ms | 1.4935 ms | 0.972x |
| NHWC | `(4, 512, 512, 3)` | `out=` | 0.8553 ms | 0.8610 ms | 0.993x |

## Validation

- `PYTHONPATH=python python -m pytest test/test_each.py -q` — 46,696 passed.

Closes #327.
