### PR TITLE
Fix Windows shared library consumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,8 @@ if (NK_BUILD_SHARED)
         # fail on unsupported OS/runtime combinations.
     endif ()
 
+    target_compile_definitions(nk_shared PUBLIC NK_DYNAMIC_DISPATCH=1 PRIVATE NK_BUILDING_LIBRARY=1)
+
     install(
         TARGETS nk_shared
         ARCHIVE

--- a/include/numkong/types.h
+++ b/include/numkong/types.h
@@ -115,7 +115,11 @@
 
 #if NK_DYNAMIC_DISPATCH
 #if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(NK_BUILDING_LIBRARY)
 #define NK_DYNAMIC __declspec(dllexport)
+#else
+#define NK_DYNAMIC __declspec(dllimport)
+#endif
 #elif defined(__GNUC__) || defined(__clang__)
 #define NK_DYNAMIC __attribute__((visibility("default")))
 #else


### PR DESCRIPTION
In the review of https://github.com/microsoft/vcpkg/pull/53425 GPT 5.6 Sol reports:

> The pre-existing `unofficial::numkong::nk_shared` target does not define `NK_DYNAMIC_DISPATCH`, so consumers compile header-only implementations rather than use `numkong.dll`. See the [upstream dispatch logic](https://github.com/ashvardanian/NumKong/blob/1a26d12bf36bcbab86127e3c57b8a3655ed97f1c/include/numkong/types.h#L99-L126). The exported target should eventually activate the dynamic API with correct platform import/export annotations.

It wrote this change.